### PR TITLE
ci: add required build-and-test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "oliver/**"
+      - "feature/**"
+      - "chore/**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: Build and test (Java 25)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+      uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      # Wrapper JAR is currently not tracked in this repository, so CI uses system Gradle.
+      - name: Run tests
+        run: gradle --no-daemon test
+
+      - name: Build project
+        run: gradle --no-daemon build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,5 @@ jobs:
           gradle-version: "9.3.1"
 
       # Wrapper JAR is currently not tracked in this repository, so CI uses the pinned Gradle version.
-      - name: Run tests
-        run: gradle --no-daemon test
-
       - name: Build project
         run: gradle --no-daemon build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
 
       - name: Set up Gradle cache
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "9.3.1"
 
-      # Wrapper JAR is currently not tracked in this repository, so CI uses system Gradle.
+      # Wrapper JAR is currently not tracked in this repository, so CI uses the pinned Gradle version.
       - name: Run tests
         run: gradle --no-daemon test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-      uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow at .github/workflows/ci.yml
- run Gradle test and build on push/PR
- use Temurin JDK 25 and Gradle caching

## Why
This ensures new code paths are continuously validated before merge.