### PR TITLE
Feature/m68k movem shift helpers & test: cover first 10 m68k instruction helpers

### DIFF
--- a/src/main/java/com/JMPE/cpu/m68k/instructions/data/Movem.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/data/Movem.java
@@ -1,4 +1,151 @@
 package com.JMPE.cpu.m68k.instructions.data;
 
-public class Movem {
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 MOVEM instruction.
+ * This helper transfers an already-decoded register list between registers and consecutive memory locations.
+ * Register-mask decoding, effective-address resolution, and address-register writeback are handled by the CPU core.
+ */
+public final class Movem {
+    public static final int EXECUTION_CYCLES = 8;
+    private static final int DATA_REGISTER_COUNT = 8;
+    private static final int ADDRESS_REGISTER_BASE = 8;
+    private static final int VALID_MASK = 0xFFFF;
+    private static final int[] FORWARD_ORDER = {
+            0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15
+    };
+    private static final int[] PREDECREMENT_ORDER = {
+            15, 14, 13, 12, 11, 10, 9, 8,
+            7, 6, 5, 4, 3, 2, 1, 0
+    };
+
+    private Movem() {
+    }
+
+    public enum AddressingMode {
+        CONTROL,
+        PREDECREMENT,
+        POSTINCREMENT
+    }
+
+    @FunctionalInterface
+    public interface RegisterReader {
+        int read(int registerIndex);
+    }
+
+    @FunctionalInterface
+    public interface RegisterWriter {
+        void write(int registerIndex, int value);
+    }
+
+    @FunctionalInterface
+    public interface MemoryReader {
+        int read(int address, Move.Size size);
+    }
+
+    @FunctionalInterface
+    public interface MemoryWriter {
+        void write(int address, Move.Size size, int value);
+    }
+
+    public static int executeRegistersToMemory(
+            Move.Size size,
+            AddressingMode addressingMode,
+            int registerMask,
+            int startAddress,
+            int effectiveAddressRegister,
+            RegisterReader registerReader,
+            MemoryWriter memoryWriter
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(addressingMode, "addressingMode must not be null");
+        Objects.requireNonNull(registerReader, "registerReader must not be null");
+        Objects.requireNonNull(memoryWriter, "memoryWriter must not be null");
+
+        validateSize(size);
+        validateEffectiveAddressRegister(effectiveAddressRegister);
+        if (addressingMode == AddressingMode.POSTINCREMENT) {
+            throw new IllegalArgumentException("POSTINCREMENT is not valid for register-to-memory MOVEM");
+        }
+
+        int[] registerOrder = addressingMode == AddressingMode.PREDECREMENT ? PREDECREMENT_ORDER : FORWARD_ORDER;
+        int normalizedMask = registerMask & VALID_MASK;
+        int address = startAddress;
+        for (int bitIndex = 0; bitIndex < registerOrder.length; bitIndex++) {
+            if (((normalizedMask >>> bitIndex) & 1) == 0) {
+                continue;
+            }
+
+            int registerIndex = registerOrder[bitIndex];
+            int value = size.mask(registerReader.read(registerIndex));
+            memoryWriter.write(address, size, value);
+            address += size.bytes();
+        }
+
+        return EXECUTION_CYCLES;
+    }
+
+    public static int executeMemoryToRegisters(
+            Move.Size size,
+            AddressingMode addressingMode,
+            int registerMask,
+            int startAddress,
+            int effectiveAddressRegister,
+            MemoryReader memoryReader,
+            RegisterWriter registerWriter
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(addressingMode, "addressingMode must not be null");
+        Objects.requireNonNull(memoryReader, "memoryReader must not be null");
+        Objects.requireNonNull(registerWriter, "registerWriter must not be null");
+
+        validateSize(size);
+        validateEffectiveAddressRegister(effectiveAddressRegister);
+        if (addressingMode == AddressingMode.PREDECREMENT) {
+            throw new IllegalArgumentException("PREDECREMENT is not valid for memory-to-register MOVEM");
+        }
+
+        int normalizedMask = registerMask & VALID_MASK;
+        int finalPostincrementAddress = startAddress + (Integer.bitCount(normalizedMask) * size.bytes());
+        int address = startAddress;
+        for (int bitIndex = 0; bitIndex < FORWARD_ORDER.length; bitIndex++) {
+            if (((normalizedMask >>> bitIndex) & 1) == 0) {
+                continue;
+            }
+
+            int registerIndex = FORWARD_ORDER[bitIndex];
+            int memoryValue = memoryReader.read(address, size);
+            int registerValue = size == Move.Size.WORD
+                    ? signExtendWord(memoryValue)
+                    : size.mask(memoryValue);
+            if (addressingMode == AddressingMode.POSTINCREMENT
+                    && effectiveAddressRegister >= 0
+                    && registerIndex == ADDRESS_REGISTER_BASE + effectiveAddressRegister) {
+                registerValue = finalPostincrementAddress;
+            }
+
+            registerWriter.write(registerIndex, registerValue);
+            address += size.bytes();
+        }
+
+        return EXECUTION_CYCLES;
+    }
+
+    private static void validateSize(Move.Size size) {
+        if (size == Move.Size.BYTE) {
+            throw new IllegalArgumentException("MOVEM only supports WORD and LONG sizes");
+        }
+    }
+
+    private static void validateEffectiveAddressRegister(int effectiveAddressRegister) {
+        if (effectiveAddressRegister < -1 || effectiveAddressRegister >= DATA_REGISTER_COUNT) {
+            throw new IllegalArgumentException("effectiveAddressRegister must be -1 or in range 0..7");
+        }
+    }
+
+    private static int signExtendWord(int value) {
+        return (short) (value & 0xFFFF);
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Asl.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Asl.java
@@ -1,4 +1,76 @@
 package com.JMPE.cpu.m68k.instructions.shift;
 
-public class Asl {
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 ASL instruction.
+ * This helper arithmetically shifts a decoded sized destination to the left, writes the sized result, and updates the CCR flags.
+ * Instruction decoding, count normalization, effective-address resolution, and operand access are handled by the CPU core.
+ */
+public final class Asl {
+    public static final int EXECUTION_CYCLES = 4;
+
+    private Asl() {
+    }
+
+    @FunctionalInterface
+    public interface DestinationReader {
+        int read();
+    }
+
+    @FunctionalInterface
+    public interface DestinationWriter {
+        void write(int value);
+    }
+
+    public interface ConditionCodes extends Move.ConditionCodes {
+        void setExtend(boolean value);
+    }
+
+    public static int execute(
+            Move.Size size,
+            int count,
+            DestinationReader destinationReader,
+            DestinationWriter destinationWriter,
+            ConditionCodes conditionCodes
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(destinationReader, "destinationReader must not be null");
+        Objects.requireNonNull(destinationWriter, "destinationWriter must not be null");
+        Objects.requireNonNull(conditionCodes, "conditionCodes must not be null");
+        validateCount(count);
+
+        int result = size.mask(destinationReader.read());
+        boolean carry = false;
+        boolean overflow = false;
+        if (count > 0) {
+            for (int shift = 0; shift < count; shift++) {
+                boolean signBeforeShift = size.isNegative(result);
+                carry = signBeforeShift;
+                result = size.mask(result << 1);
+                boolean signAfterShift = size.isNegative(result);
+                if (signBeforeShift != signAfterShift) {
+                    overflow = true;
+                }
+            }
+        }
+
+        destinationWriter.write(result);
+        conditionCodes.setNegative(size.isNegative(result));
+        conditionCodes.setZero(size.isZero(result));
+        conditionCodes.setOverflow(overflow);
+        conditionCodes.setCarry(carry);
+        if (count > 0) {
+            conditionCodes.setExtend(carry);
+        }
+        return EXECUTION_CYCLES;
+    }
+
+    private static void validateCount(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be >= 0");
+        }
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Asr.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Asr.java
@@ -1,4 +1,80 @@
 package com.JMPE.cpu.m68k.instructions.shift;
 
-public class Asr {
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 ASR instruction.
+ * This helper arithmetically shifts a decoded sized destination to the right, writes the sized result, and updates the CCR flags.
+ * Instruction decoding, count normalization, effective-address resolution, and operand access are handled by the CPU core.
+ */
+public final class Asr {
+    public static final int EXECUTION_CYCLES = 4;
+
+    private Asr() {
+    }
+
+    @FunctionalInterface
+    public interface DestinationReader {
+        int read();
+    }
+
+    @FunctionalInterface
+    public interface DestinationWriter {
+        void write(int value);
+    }
+
+    public interface ConditionCodes extends Move.ConditionCodes {
+        void setExtend(boolean value);
+    }
+
+    public static int execute(
+            Move.Size size,
+            int count,
+            DestinationReader destinationReader,
+            DestinationWriter destinationWriter,
+            ConditionCodes conditionCodes
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(destinationReader, "destinationReader must not be null");
+        Objects.requireNonNull(destinationWriter, "destinationWriter must not be null");
+        Objects.requireNonNull(conditionCodes, "conditionCodes must not be null");
+        validateCount(count);
+
+        int maskedValue = size.mask(destinationReader.read());
+        int current = signExtend(size, maskedValue);
+        boolean carry = false;
+        if (count > 0) {
+            for (int shift = 0; shift < count; shift++) {
+                carry = (current & 1) != 0;
+                current = current >> 1;
+            }
+        }
+
+        int result = size.mask(current);
+        destinationWriter.write(result);
+        conditionCodes.setNegative(size.isNegative(result));
+        conditionCodes.setZero(size.isZero(result));
+        conditionCodes.setOverflow(false);
+        conditionCodes.setCarry(carry);
+        if (count > 0) {
+            conditionCodes.setExtend(carry);
+        }
+        return EXECUTION_CYCLES;
+    }
+
+    private static int signExtend(Move.Size size, int value) {
+        return switch (size) {
+            case BYTE -> (byte) value;
+            case WORD -> (short) value;
+            case LONG -> value;
+        };
+    }
+
+    private static void validateCount(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be >= 0");
+        }
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Lsl.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Lsl.java
@@ -1,4 +1,70 @@
 package com.JMPE.cpu.m68k.instructions.shift;
 
-public class Lsl {
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 LSL instruction.
+ * This helper logically shifts a decoded sized destination to the left, writes the sized result, and updates the CCR flags.
+ * Instruction decoding, count normalization, effective-address resolution, and operand access are handled by the CPU core.
+ */
+public final class Lsl {
+    public static final int EXECUTION_CYCLES = 4;
+
+    private Lsl() {
+    }
+
+    @FunctionalInterface
+    public interface DestinationReader {
+        int read();
+    }
+
+    @FunctionalInterface
+    public interface DestinationWriter {
+        void write(int value);
+    }
+
+    public interface ConditionCodes extends Move.ConditionCodes {
+        void setExtend(boolean value);
+    }
+
+    public static int execute(
+            Move.Size size,
+            int count,
+            DestinationReader destinationReader,
+            DestinationWriter destinationWriter,
+            ConditionCodes conditionCodes
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(destinationReader, "destinationReader must not be null");
+        Objects.requireNonNull(destinationWriter, "destinationWriter must not be null");
+        Objects.requireNonNull(conditionCodes, "conditionCodes must not be null");
+        validateCount(count);
+
+        int result = size.mask(destinationReader.read());
+        boolean carry = false;
+        if (count > 0) {
+            for (int shift = 0; shift < count; shift++) {
+                carry = size.isNegative(result);
+                result = size.mask(result << 1);
+            }
+        }
+
+        destinationWriter.write(result);
+        conditionCodes.setNegative(size.isNegative(result));
+        conditionCodes.setZero(size.isZero(result));
+        conditionCodes.setOverflow(false);
+        conditionCodes.setCarry(carry);
+        if (count > 0) {
+            conditionCodes.setExtend(carry);
+        }
+        return EXECUTION_CYCLES;
+    }
+
+    private static void validateCount(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be >= 0");
+        }
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Lsr.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Lsr.java
@@ -1,4 +1,71 @@
 package com.JMPE.cpu.m68k.instructions.shift;
 
-public class Lsr {
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 LSR instruction.
+ * This helper logically shifts a decoded sized destination to the right, writes the sized result, and updates the CCR flags.
+ * Instruction decoding, count normalization, effective-address resolution, and operand access are handled by the CPU core.
+ */
+public final class Lsr {
+    public static final int EXECUTION_CYCLES = 4;
+
+    private Lsr() {
+    }
+
+    @FunctionalInterface
+    public interface DestinationReader {
+        int read();
+    }
+
+    @FunctionalInterface
+    public interface DestinationWriter {
+        void write(int value);
+    }
+
+    public interface ConditionCodes extends Move.ConditionCodes {
+        void setExtend(boolean value);
+    }
+
+    public static int execute(
+            Move.Size size,
+            int count,
+            DestinationReader destinationReader,
+            DestinationWriter destinationWriter,
+            ConditionCodes conditionCodes
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(destinationReader, "destinationReader must not be null");
+        Objects.requireNonNull(destinationWriter, "destinationWriter must not be null");
+        Objects.requireNonNull(conditionCodes, "conditionCodes must not be null");
+        validateCount(count);
+
+        int result = size.mask(destinationReader.read());
+        boolean carry = false;
+        if (count > 0) {
+            for (int shift = 0; shift < count; shift++) {
+                carry = (result & 1) != 0;
+                result = result >>> 1;
+            }
+            result = size.mask(result);
+        }
+
+        destinationWriter.write(result);
+        conditionCodes.setNegative(size.isNegative(result));
+        conditionCodes.setZero(size.isZero(result));
+        conditionCodes.setOverflow(false);
+        conditionCodes.setCarry(carry);
+        if (count > 0) {
+            conditionCodes.setExtend(carry);
+        }
+        return EXECUTION_CYCLES;
+    }
+
+    private static void validateCount(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be >= 0");
+        }
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Rol.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Rol.java
@@ -1,4 +1,66 @@
 package com.JMPE.cpu.m68k.instructions.shift;
 
-public class Rol {
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 ROL instruction.
+ * This helper rotates a decoded sized destination to the left, writes the sized result, and updates the CCR flags.
+ * Instruction decoding, count normalization, effective-address resolution, and operand access are handled by the CPU core.
+ */
+public final class Rol {
+    public static final int EXECUTION_CYCLES = 4;
+
+    private Rol() {
+    }
+
+    @FunctionalInterface
+    public interface DestinationReader {
+        int read();
+    }
+
+    @FunctionalInterface
+    public interface DestinationWriter {
+        void write(int value);
+    }
+
+    public static int execute(
+            Move.Size size,
+            int count,
+            DestinationReader destinationReader,
+            DestinationWriter destinationWriter,
+            Move.ConditionCodes conditionCodes
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(destinationReader, "destinationReader must not be null");
+        Objects.requireNonNull(destinationWriter, "destinationWriter must not be null");
+        Objects.requireNonNull(conditionCodes, "conditionCodes must not be null");
+        validateCount(count);
+
+        int result = size.mask(destinationReader.read());
+        boolean carry = false;
+        if (count > 0) {
+            for (int rotate = 0; rotate < count; rotate++) {
+                carry = size.isNegative(result);
+                result = size.mask(result << 1);
+                if (carry) {
+                    result |= 1;
+                }
+            }
+        }
+
+        destinationWriter.write(result);
+        conditionCodes.setNegative(size.isNegative(result));
+        conditionCodes.setZero(size.isZero(result));
+        conditionCodes.setOverflow(false);
+        conditionCodes.setCarry(carry);
+        return EXECUTION_CYCLES;
+    }
+
+    private static void validateCount(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be >= 0");
+        }
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Ror.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/shift/Ror.java
@@ -1,4 +1,76 @@
 package com.JMPE.cpu.m68k.instructions.shift;
 
-public class Ror {
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
+import java.util.Objects;
+
+/**
+ * Implements the execution semantics of the Motorola 68000 ROR instruction.
+ * This helper rotates a decoded sized destination to the right, writes the sized result, and updates the CCR flags.
+ * Instruction decoding, count normalization, effective-address resolution, and operand access are handled by the CPU core.
+ */
+public final class Ror {
+    public static final int EXECUTION_CYCLES = 4;
+
+    private Ror() {
+    }
+
+    @FunctionalInterface
+    public interface DestinationReader {
+        int read();
+    }
+
+    @FunctionalInterface
+    public interface DestinationWriter {
+        void write(int value);
+    }
+
+    public static int execute(
+            Move.Size size,
+            int count,
+            DestinationReader destinationReader,
+            DestinationWriter destinationWriter,
+            Move.ConditionCodes conditionCodes
+    ) {
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(destinationReader, "destinationReader must not be null");
+        Objects.requireNonNull(destinationWriter, "destinationWriter must not be null");
+        Objects.requireNonNull(conditionCodes, "conditionCodes must not be null");
+        validateCount(count);
+
+        int result = size.mask(destinationReader.read());
+        int signBitMask = signBitMask(size);
+        boolean carry = false;
+        if (count > 0) {
+            for (int rotate = 0; rotate < count; rotate++) {
+                carry = (result & 1) != 0;
+                result = result >>> 1;
+                if (carry) {
+                    result |= signBitMask;
+                }
+                result = size.mask(result);
+            }
+        }
+
+        destinationWriter.write(result);
+        conditionCodes.setNegative(size.isNegative(result));
+        conditionCodes.setZero(size.isZero(result));
+        conditionCodes.setOverflow(false);
+        conditionCodes.setCarry(carry);
+        return EXECUTION_CYCLES;
+    }
+
+    private static int signBitMask(Move.Size size) {
+        return switch (size) {
+            case BYTE -> 0x0000_0080;
+            case WORD -> 0x0000_8000;
+            case LONG -> 0x8000_0000;
+        };
+    }
+
+    private static void validateCount(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be >= 0");
+        }
+    }
 }

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/arithmetic/Addq_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/arithmetic/Addq_Test.java
@@ -1,0 +1,106 @@
+package com.JMPE.cpu.m68k.instructions.arithmetic;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Addq_Test {
+    @Test
+    void executeSetsZeroCarryAndExtendOnUnsignedWrap() {
+        AtomicInteger writtenValue = new AtomicInteger(-1);
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = Addq.execute(Move.Size.BYTE, 1, () -> 0x00FF, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Addq.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeSetsOverflowForSignedPositiveOverflow() {
+        AtomicInteger writtenValue = new AtomicInteger(-1);
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        Addq.execute(Move.Size.BYTE, 1, () -> 0x007F, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x0080, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertTrue(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeRejectsQuickValuesOutsideOneToEight() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        assertAll(
+                () -> assertEquals(
+                        "quickValue must be in range 1..8",
+                        assertThrows(
+                                IllegalArgumentException.class,
+                                () -> Addq.execute(Move.Size.WORD, 0, () -> 0, value -> {
+                                }, conditionCodes)
+                        ).getMessage()
+                ),
+                () -> assertEquals(
+                        "quickValue must be in range 1..8",
+                        assertThrows(
+                                IllegalArgumentException.class,
+                                () -> Addq.execute(Move.Size.WORD, 9, () -> 0, value -> {
+                                }, conditionCodes)
+                        ).getMessage()
+                )
+        );
+    }
+
+    private static final class TrackingConditionCodes implements Addq.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean extend;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            extend = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/arithmetic/Cmp_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/arithmetic/Cmp_Test.java
@@ -1,0 +1,81 @@
+package com.JMPE.cpu.m68k.instructions.arithmetic;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Cmp_Test {
+    @Test
+    void executeSetsZeroForEqualOperands() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = Cmp.execute(Move.Size.WORD, () -> 0x1234, () -> 0x1234, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Cmp.EXECUTION_CYCLES, cycles),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeSetsNegativeAndCarryWhenUnsignedBorrowOccurs() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        Cmp.execute(Move.Size.WORD, () -> 0x0001, () -> 0x0000, conditionCodes);
+
+        assertAll(
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeSetsOverflowForSignedWraparoundCase() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        Cmp.execute(Move.Size.BYTE, () -> 0x01, () -> 0x80, conditionCodes);
+
+        assertAll(
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    private static final class TrackingConditionCodes implements Move.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/arithmetic/Subq_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/arithmetic/Subq_Test.java
@@ -1,0 +1,106 @@
+package com.JMPE.cpu.m68k.instructions.arithmetic;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Subq_Test {
+    @Test
+    void executeSetsNegativeCarryAndExtendOnBorrow() {
+        AtomicInteger writtenValue = new AtomicInteger(-1);
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = Subq.execute(Move.Size.BYTE, 1, () -> 0x0000, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Subq.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0x00FF, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeSetsOverflowForSignedNegativeOverflow() {
+        AtomicInteger writtenValue = new AtomicInteger(-1);
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        Subq.execute(Move.Size.BYTE, 1, () -> 0x0080, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x007F, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertTrue(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeRejectsQuickValuesOutsideOneToEight() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        assertAll(
+                () -> assertEquals(
+                        "quickValue must be in range 1..8",
+                        assertThrows(
+                                IllegalArgumentException.class,
+                                () -> Subq.execute(Move.Size.WORD, 0, () -> 0, value -> {
+                                }, conditionCodes)
+                        ).getMessage()
+                ),
+                () -> assertEquals(
+                        "quickValue must be in range 1..8",
+                        assertThrows(
+                                IllegalArgumentException.class,
+                                () -> Subq.execute(Move.Size.WORD, 9, () -> 0, value -> {
+                                }, conditionCodes)
+                        ).getMessage()
+                )
+        );
+    }
+
+    private static final class TrackingConditionCodes implements Subq.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean extend;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            extend = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/control/Bcc_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/control/Bcc_Test.java
@@ -1,0 +1,85 @@
+package com.JMPE.cpu.m68k.instructions.control;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Bcc_Test {
+    @Test
+    void executeWritesProgramCounterWhenConditionIsTrue() {
+        AtomicInteger newPc = new AtomicInteger(Integer.MIN_VALUE);
+
+        int cycles = Bcc.execute(
+                Bcc.Condition.EQ,
+                0x1000,
+                0x20,
+                new TrackingConditionCodesReader(false, true, false, false),
+                newPc::set
+        );
+
+        assertAll(
+                () -> assertEquals(Bcc.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0x1020, newPc.get())
+        );
+    }
+
+    @Test
+    void executeLeavesProgramCounterUntouchedWhenConditionIsFalse() {
+        AtomicBoolean wrotePc = new AtomicBoolean(false);
+
+        int cycles = Bcc.execute(
+                Bcc.Condition.EQ,
+                0x1000,
+                0x20,
+                new TrackingConditionCodesReader(false, false, false, false),
+                value -> wrotePc.set(true)
+        );
+
+        assertAll(
+                () -> assertEquals(Bcc.EXECUTION_CYCLES, cycles),
+                () -> assertFalse(wrotePc.get())
+        );
+    }
+
+    @Test
+    void isConditionTrueEvaluatesRepresentativeUnsignedAndSignedCases() {
+        assertAll(
+                () -> assertTrue(Bcc.isConditionTrue(Bcc.Condition.HI, new TrackingConditionCodesReader(false, false, false, false))),
+                () -> assertTrue(Bcc.isConditionTrue(Bcc.Condition.LS, new TrackingConditionCodesReader(false, false, false, true))),
+                () -> assertTrue(Bcc.isConditionTrue(Bcc.Condition.GE, new TrackingConditionCodesReader(true, false, true, false))),
+                () -> assertTrue(Bcc.isConditionTrue(Bcc.Condition.LT, new TrackingConditionCodesReader(true, false, false, false))),
+                () -> assertTrue(Bcc.isConditionTrue(Bcc.Condition.GT, new TrackingConditionCodesReader(false, false, false, false))),
+                () -> assertTrue(Bcc.isConditionTrue(Bcc.Condition.LE, new TrackingConditionCodesReader(false, true, false, false))),
+                () -> assertFalse(Bcc.isConditionTrue(Bcc.Condition.CC, new TrackingConditionCodesReader(false, false, false, true)))
+        );
+    }
+
+    private record TrackingConditionCodesReader(boolean negative, boolean zero, boolean overflow, boolean carry)
+            implements Bcc.ConditionCodesReader {
+        @Override
+        public boolean isNegative() {
+            return negative;
+        }
+
+        @Override
+        public boolean isZero() {
+            return zero;
+        }
+
+        @Override
+        public boolean isOverflow() {
+            return overflow;
+        }
+
+        @Override
+        public boolean isCarry() {
+            return carry;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/control/Bra_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/control/Bra_Test.java
@@ -1,0 +1,33 @@
+package com.JMPE.cpu.m68k.instructions.control;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Bra_Test {
+    @Test
+    void executeWritesDisplacedProgramCounter() {
+        AtomicInteger newPc = new AtomicInteger(Integer.MIN_VALUE);
+
+        int cycles = Bra.execute(0x1000, 0x20, newPc::set);
+
+        assertAll(
+                () -> assertEquals(Bra.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0x1020, newPc.get())
+        );
+    }
+
+    @Test
+    void executeRejectsNullPcWriter() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> Bra.execute(0x1000, 0x20, null)
+        );
+
+        assertEquals("pcWriter must not be null", exception.getMessage());
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/control/Jsr_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/control/Jsr_Test.java
@@ -1,0 +1,39 @@
+package com.JMPE.cpu.m68k.instructions.control;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Jsr_Test {
+    @Test
+    void executePushesReturnAddressBeforeUpdatingProgramCounter() {
+        List<String> events = new ArrayList<>();
+        AtomicInteger pushedValue = new AtomicInteger();
+        AtomicInteger writtenPc = new AtomicInteger();
+
+        int cycles = Jsr.execute(
+                0x0200,
+                0x1000,
+                value -> {
+                    events.add("push");
+                    pushedValue.set(value);
+                },
+                value -> {
+                    events.add("pc");
+                    writtenPc.set(value);
+                }
+        );
+
+        assertAll(
+                () -> assertEquals(Jsr.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(List.of("push", "pc"), events),
+                () -> assertEquals(0x0200, pushedValue.get()),
+                () -> assertEquals(0x1000, writtenPc.get())
+        );
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/control/Rts_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/control/Rts_Test.java
@@ -1,0 +1,35 @@
+package com.JMPE.cpu.m68k.instructions.control;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Rts_Test {
+    @Test
+    void executePopsReturnAddressBeforeUpdatingProgramCounter() {
+        List<String> events = new ArrayList<>();
+        AtomicInteger writtenPc = new AtomicInteger();
+
+        int cycles = Rts.execute(
+                () -> {
+                    events.add("pop");
+                    return 0x00AB_CDEF;
+                },
+                value -> {
+                    events.add("pc");
+                    writtenPc.set(value);
+                }
+        );
+
+        assertAll(
+                () -> assertEquals(Rts.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(List.of("pop", "pc"), events),
+                () -> assertEquals(0x00AB_CDEF, writtenPc.get())
+        );
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/Lea_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/Lea_Test.java
@@ -1,0 +1,38 @@
+package com.JMPE.cpu.m68k.instructions.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Lea_Test {
+    @Test
+    void executeWritesEffectiveAddressToSelectedAddressRegister() {
+        AtomicInteger registerIndex = new AtomicInteger(-1);
+        AtomicInteger writtenValue = new AtomicInteger();
+
+        int cycles = Lea.execute(5, 0x1234_5678, (register, value) -> {
+            registerIndex.set(register);
+            writtenValue.set(value);
+        });
+
+        assertAll(
+                () -> assertEquals(Lea.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(5, registerIndex.get()),
+                () -> assertEquals(0x1234_5678, writtenValue.get())
+        );
+    }
+
+    @Test
+    void executeRejectsNullWriter() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> Lea.execute(0, 0x1000, null)
+        );
+
+        assertEquals("writer must not be null", exception.getMessage());
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/MoveQ_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/MoveQ_Test.java
@@ -26,8 +26,7 @@ public class MoveQ_Test {
                 () -> assertTrue(conditionCodes.negative),
                 () -> assertFalse(conditionCodes.zero),
                 () -> assertFalse(conditionCodes.overflow),
-                () -> assertFalse(conditionCodes.carry),
-                () -> assertTrue(conditionCodes.externalXState)
+                () -> assertFalse(conditionCodes.carry)
         );
     }
 
@@ -91,7 +90,6 @@ public class MoveQ_Test {
         private boolean zero;
         private boolean overflow;
         private boolean carry;
-        private boolean externalXState = true;
 
         @Override
         public void setNegative(boolean value) {

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/MoveQ_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/MoveQ_Test.java
@@ -1,0 +1,116 @@
+package com.JMPE.cpu.m68k.instructions.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MoveQ_Test {
+    @Test
+    void executeWritesSignExtendedNegativeLongAndUpdatesCcr() {
+        AtomicInteger registerIndex = new AtomicInteger(-1);
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = MoveQ.execute(3, 0x80, writeLong(registerIndex, writtenValue), conditionCodes);
+
+        assertAll(
+                () -> assertEquals(MoveQ.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(3, registerIndex.get()),
+                () -> assertEquals(-128, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.externalXState)
+        );
+    }
+
+    @Test
+    void executeSetsZeroForZeroImmediate() {
+        AtomicInteger writtenValue = new AtomicInteger(Integer.MIN_VALUE);
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        MoveQ.execute(0, 0x00, (register, value) -> writtenValue.set(value), conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void signExtend8UsesOnlyLowByte() {
+        assertAll(
+                () -> assertEquals(-1, MoveQ.signExtend8(0x01FF)),
+                () -> assertEquals(127, MoveQ.signExtend8(0x007F))
+        );
+    }
+
+    @Test
+    void executeRejectsRegistersOutsideDataRegisterRange() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        assertAll(
+                () -> assertEquals(
+                        "destinationRegister must be in range 0..7",
+                        assertThrows(
+                                IllegalArgumentException.class,
+                                () -> MoveQ.execute(-1, 0x12, (register, value) -> {
+                                }, conditionCodes)
+                        ).getMessage()
+                ),
+                () -> assertEquals(
+                        "destinationRegister must be in range 0..7",
+                        assertThrows(
+                                IllegalArgumentException.class,
+                                () -> MoveQ.execute(8, 0x12, (register, value) -> {
+                                }, conditionCodes)
+                        ).getMessage()
+                )
+        );
+    }
+
+    private MoveQ.DataRegisterWriter writeLong(AtomicInteger registerIndex, AtomicInteger writtenValue) {
+        return (register, value) -> {
+            registerIndex.set(register);
+            writtenValue.set(value);
+        };
+    }
+
+    private static final class TrackingConditionCodes implements Move.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean externalXState = true;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/Move_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/Move_Test.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Move_Test {
     @Test
-    void executeMasksByteResultUpdatesCcrAndLeavesExternalXStateUntouched() {
+    void executeMasksByteResultUpdatesCcr() {
         AtomicInteger writtenValue = new AtomicInteger();
         TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
 
@@ -24,8 +24,7 @@ public class Move_Test {
                 () -> assertTrue(conditionCodes.negative),
                 () -> assertFalse(conditionCodes.zero),
                 () -> assertFalse(conditionCodes.overflow),
-                () -> assertFalse(conditionCodes.carry),
-                () -> assertTrue(conditionCodes.externalXState)
+                () -> assertFalse(conditionCodes.carry)
         );
     }
 
@@ -77,7 +76,6 @@ public class Move_Test {
         private boolean zero;
         private boolean overflow;
         private boolean carry;
-        private boolean externalXState = true;
 
         @Override
         public void setNegative(boolean value) {

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/Move_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/Move_Test.java
@@ -1,0 +1,102 @@
+package com.JMPE.cpu.m68k.instructions.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Move_Test {
+    @Test
+    void executeMasksByteResultUpdatesCcrAndLeavesExternalXStateUntouched() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = Move.execute(Move.Size.BYTE, 0x01FF, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Move.DEFAULT_CYCLES, cycles),
+                () -> assertEquals(0x00FF, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.externalXState)
+        );
+    }
+
+    @Test
+    void executeSetsZeroAndClearsNegativeForMaskedWordZero() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        Move.execute(Move.Size.WORD, 0x0001_0000, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeReturnsExplicitCycleCount() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = Move.execute(Move.Size.LONG, 0x1234_5678, writtenValue::set, conditionCodes, 12);
+
+        assertAll(
+                () -> assertEquals(12, cycles),
+                () -> assertEquals(0x1234_5678, writtenValue.get()),
+                () -> assertFalse(conditionCodes.zero)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCycleCounts() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Move.execute(Move.Size.WORD, 0x1234, value -> {
+                }, conditionCodes, -1)
+        );
+
+        assertEquals("cycles must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Move.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean externalXState = true;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/Movem_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/Movem_Test.java
@@ -1,0 +1,179 @@
+package com.JMPE.cpu.m68k.instructions.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Movem_Test {
+    @Test
+    void executeRegistersToMemory_writesSelectedRegistersInForwardOrder() {
+        int[] registers = new int[16];
+        registers[0] = 0x1111;  // D0 selected by bit 0
+        registers[1] = 0x2222;  // D1 selected by bit 1
+
+        List<Integer> writtenAddresses = new ArrayList<>();
+        List<Integer> writtenValues = new ArrayList<>();
+
+        // mask = 0x0003: bits 0 and 1 → D0 then D1, in forward order.
+        int cycles = Movem.executeRegistersToMemory(
+                Move.Size.WORD,
+                Movem.AddressingMode.CONTROL,
+                0x0003,
+                0x1000,
+                -1,
+                index -> registers[index],
+                (address, size, value) -> {
+                    writtenAddresses.add(address);
+                    writtenValues.add(value);
+                }
+        );
+
+        assertAll(
+                () -> assertEquals(Movem.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(List.of(0x1000, 0x1002), writtenAddresses),
+                () -> assertEquals(List.of(0x1111, 0x2222), writtenValues)
+        );
+    }
+
+    @Test
+    void executeRegistersToMemory_writesA7ThenA6ForBit0AndBit1InPredecrementMode() {
+        int[] registers = new int[16];
+        registers[15] = 0xAAAA;  // A7 → predecrement bit 0 maps here
+        registers[14] = 0xBBBB;  // A6 → predecrement bit 1 maps here
+
+        List<Integer> writtenValues = new ArrayList<>();
+
+        // mask = 0x0003: bits 0 and 1 → PREDECREMENT_ORDER[0]=A7, PREDECREMENT_ORDER[1]=A6.
+        Movem.executeRegistersToMemory(
+                Move.Size.WORD,
+                Movem.AddressingMode.PREDECREMENT,
+                0x0003,
+                0x1000,
+                0,
+                index -> registers[index],
+                (address, size, value) -> writtenValues.add(value)
+        );
+
+        assertEquals(List.of(0xAAAA, 0xBBBB), writtenValues);
+    }
+
+    @Test
+    void executeRegistersToMemory_rejectsPostincrementMode() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Movem.executeRegistersToMemory(
+                        Move.Size.WORD,
+                        Movem.AddressingMode.POSTINCREMENT,
+                        0x00FF,
+                        0x1000,
+                        -1,
+                        index -> 0,
+                        (address, size, value) -> {}
+                )
+        );
+
+        assertEquals("POSTINCREMENT is not valid for register-to-memory MOVEM", exception.getMessage());
+    }
+
+    @Test
+    void executeRegistersToMemory_rejectsByteSize() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Movem.executeRegistersToMemory(
+                        Move.Size.BYTE,
+                        Movem.AddressingMode.CONTROL,
+                        0x00FF,
+                        0x1000,
+                        -1,
+                        index -> 0,
+                        (address, size, value) -> {}
+                )
+        );
+
+        assertEquals("MOVEM only supports WORD and LONG sizes", exception.getMessage());
+    }
+
+    @Test
+    void executeMemoryToRegisters_writesLongValuesIntoSelectedRegisters() {
+        // memory[0x1000]=0xABCD1234, memory[0x1004]=0x56789ABC
+        int[] values = { 0xABCD1234, 0x56789ABC };
+
+        int[] registers = new int[16];
+
+        // mask = 0x0003: bits 0 and 1 → D0 (register 0) and D1 (register 1).
+        int cycles = Movem.executeMemoryToRegisters(
+                Move.Size.LONG,
+                Movem.AddressingMode.POSTINCREMENT,
+                0x0003,
+                0x1000,
+                -1,
+                (address, size) -> values[(address - 0x1000) / size.bytes()],
+                (index, value) -> registers[index] = value
+        );
+
+        assertAll(
+                () -> assertEquals(Movem.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0xABCD1234, registers[0]),
+                () -> assertEquals(0x56789ABC, registers[1])
+        );
+    }
+
+    @Test
+    void executeMemoryToRegisters_signExtendsWordValues() {
+        int[] registers = new int[16];
+
+        // mask = 0x0001: bit 0 → D0. Reading 0x8000 as WORD sign-extends to 0xFFFF8000.
+        Movem.executeMemoryToRegisters(
+                Move.Size.WORD,
+                Movem.AddressingMode.POSTINCREMENT,
+                0x0001,
+                0x1000,
+                -1,
+                (address, size) -> 0x8000,
+                (index, value) -> registers[index] = value
+        );
+
+        assertEquals((int) 0xFFFF8000, registers[0]);
+    }
+
+    @Test
+    void executeMemoryToRegisters_rejectsPredecrementMode() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Movem.executeMemoryToRegisters(
+                        Move.Size.WORD,
+                        Movem.AddressingMode.PREDECREMENT,
+                        0x00FF,
+                        0x1000,
+                        -1,
+                        (address, size) -> 0,
+                        (index, value) -> {}
+                )
+        );
+
+        assertEquals("PREDECREMENT is not valid for memory-to-register MOVEM", exception.getMessage());
+    }
+
+    @Test
+    void executeMemoryToRegisters_rejectsByteSize() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Movem.executeMemoryToRegisters(
+                        Move.Size.BYTE,
+                        Movem.AddressingMode.POSTINCREMENT,
+                        0x00FF,
+                        0x1000,
+                        -1,
+                        (address, size) -> 0,
+                        (index, value) -> {}
+                )
+        );
+
+        assertEquals("MOVEM only supports WORD and LONG sizes", exception.getMessage());
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Asl_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Asl_Test.java
@@ -1,0 +1,114 @@
+package com.JMPE.cpu.m68k.instructions.shift;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Asl_Test {
+    @Test
+    void executeSetsCarryExtendAndOverflowOnByteShiftOfMSB() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x80 left by 1: MSB becomes carry, result wraps to 0, sign flips 1→0 so overflow is set.
+        int cycles = Asl.execute(Move.Size.BYTE, 1, () -> 0x80, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Asl.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertTrue(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeSetsOverflowAndNegativeWhenSignFlipsFromZeroToOne() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x40 left by 1: sign changes from 0 to 1, so overflow is set.
+        Asl.execute(Move.Size.BYTE, 1, () -> 0x40, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x80, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertTrue(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeWithZeroCountLeavesResultAndDoesNotSetExtend() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // count=0: no shift; extend is never written; flags reflect the original value.
+        Asl.execute(Move.Size.BYTE, 0, () -> 0x01, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x01, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCount() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Asl.execute(Move.Size.BYTE, -1, () -> 0, value -> {}, conditionCodes)
+        );
+
+        assertEquals("count must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Asl.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean extend;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            extend = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Asr_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Asr_Test.java
@@ -1,0 +1,114 @@
+package com.JMPE.cpu.m68k.instructions.shift;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Asr_Test {
+    @Test
+    void executePreservesSignBitForNegativeByteValue() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // 0x80 sign-extended is -128; right-shifted by 1 gives -64 (0xC0). Sign is preserved.
+        int cycles = Asr.execute(Move.Size.BYTE, 1, () -> 0x80, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Asr.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0xC0, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeSetsCarryAndExtendFromLeastSignificantBit() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x01 right by 1: LSB becomes carry; result is 0.
+        Asr.execute(Move.Size.BYTE, 1, () -> 0x01, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeWithZeroCountLeavesResultAndDoesNotSetExtend() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // count=0: no shift; extend is never written; flags reflect the original value.
+        Asr.execute(Move.Size.BYTE, 0, () -> 0x42, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x42, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCount() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Asr.execute(Move.Size.BYTE, -1, () -> 0, value -> {}, conditionCodes)
+        );
+
+        assertEquals("count must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Asr.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean extend;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            extend = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Lsl_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Lsl_Test.java
@@ -1,0 +1,114 @@
+package com.JMPE.cpu.m68k.instructions.shift;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Lsl_Test {
+    @Test
+    void executeSetsCarryAndExtendFromMSBAndNeverSetsOverflow() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x80 left by 1: MSB becomes carry, result wraps to 0. V is always clear for LSL.
+        int cycles = Lsl.execute(Move.Size.BYTE, 1, () -> 0x80, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Lsl.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeShiftsWordValueLeftAndSetsNegative() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x4000 left by 1: result is 0x8000 (negative word), no carry.
+        Lsl.execute(Move.Size.WORD, 1, () -> 0x4000, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x8000, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeWithZeroCountLeavesResultAndDoesNotSetExtend() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // count=0: no shift; extend is never written.
+        Lsl.execute(Move.Size.BYTE, 0, () -> 0x55, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x55, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCount() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Lsl.execute(Move.Size.BYTE, -1, () -> 0, value -> {}, conditionCodes)
+        );
+
+        assertEquals("count must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Lsl.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean extend;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            extend = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Lsr_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Lsr_Test.java
@@ -1,0 +1,114 @@
+package com.JMPE.cpu.m68k.instructions.shift;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Lsr_Test {
+    @Test
+    void executeSetsCarryAndExtendFromLSBAndDoesNotSignExtend() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x01 right by 1: LSB becomes carry, result is 0. No sign extension.
+        int cycles = Lsr.execute(Move.Size.BYTE, 1, () -> 0x01, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Lsr.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry),
+                () -> assertTrue(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeDoesNotPreserveSignBitUnlikeArithmeticShift() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Shifting 0x80 right by 1 logically: result is 0x40, not 0xC0 (no sign extension).
+        Lsr.execute(Move.Size.BYTE, 1, () -> 0x80, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x40, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeWithZeroCountLeavesResultAndDoesNotSetExtend() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // count=0: no shift; extend is never written.
+        Lsr.execute(Move.Size.BYTE, 0, () -> 0x42, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x42, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry),
+                () -> assertFalse(conditionCodes.extend)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCount() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Lsr.execute(Move.Size.BYTE, -1, () -> 0, value -> {}, conditionCodes)
+        );
+
+        assertEquals("count must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Lsr.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+        private boolean extend;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            extend = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Rol_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Rol_Test.java
@@ -1,0 +1,105 @@
+package com.JMPE.cpu.m68k.instructions.shift;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Rol_Test {
+    @Test
+    void executeRotatesMSBIntoLSBAndSetsCarry() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Rotating 0x80 left by 1: MSB wraps into bit 0, carry reflects the shifted-out MSB.
+        int cycles = Rol.execute(Move.Size.BYTE, 1, () -> 0x80, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Rol.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0x01, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeRotatesWordValueAndSetsNegative() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Rotating 0x4000 left by 1: result is 0x8000 (MSB set = negative word), no carry.
+        Rol.execute(Move.Size.WORD, 1, () -> 0x4000, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x8000, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeWithZeroCountLeavesResultAndClearsCarry() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // count=0: no rotation; carry is cleared.
+        Rol.execute(Move.Size.BYTE, 0, () -> 0x42, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x42, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCount() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Rol.execute(Move.Size.BYTE, -1, () -> 0, value -> {}, conditionCodes)
+        );
+
+        assertEquals("count must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Move.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Ror_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/shift/Ror_Test.java
@@ -1,0 +1,105 @@
+package com.JMPE.cpu.m68k.instructions.shift;
+
+import com.JMPE.cpu.m68k.instructions.data.Move;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Ror_Test {
+    @Test
+    void executeRotatesLSBIntoMSBAndSetsCarry() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Rotating 0x01 right by 1: LSB wraps into MSB (0x80), carry reflects the shifted-out LSB.
+        int cycles = Ror.execute(Move.Size.BYTE, 1, () -> 0x01, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Ror.EXECUTION_CYCLES, cycles),
+                () -> assertEquals(0x80, writtenValue.get()),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertTrue(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeRotatesWordValueRightAndClearsNegative() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // Rotating 0x8000 right by 1: MSB shifts to bit 14 (0x4000), no carry since LSB was 0.
+        Ror.execute(Move.Size.WORD, 1, () -> 0x8000, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x4000, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeWithZeroCountLeavesResultAndClearsCarry() {
+        AtomicInteger writtenValue = new AtomicInteger();
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        // count=0: no rotation; carry is cleared.
+        Ror.execute(Move.Size.BYTE, 0, () -> 0x55, writtenValue::set, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(0x55, writtenValue.get()),
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeRejectsNegativeCount() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Ror.execute(Move.Size.BYTE, -1, () -> 0, value -> {}, conditionCodes)
+        );
+
+        assertEquals("count must be >= 0", exception.getMessage());
+    }
+
+    private static final class TrackingConditionCodes implements Move.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+    }
+}


### PR DESCRIPTION
 Adds focused helper-level JUnit coverage for the first 10 Motorola 68000 instruction
 helpers we want to stabilize before decoder integration:
 
 - `MOVE`
 - `MOVEQ`
 - `LEA`
 - `CMP`
 - `ADDQ`
 - `SUBQ`
 - `BRA`
 - `BCC`
 - `JSR`
 - `RTS`
 
 ## What this PR does
 
 - adds instruction-helper tests under 
`src/test/java/com/JMPE/cpu/m68k/instructions/**`
 - verifies CCR behavior for arithmetic/compare cases
 - verifies control-flow helper behavior for branch/jump/subroutine helpers
 - keeps scope limited to tests and helper validation
 
 ## What this PR does not do
 
 - decoder wiring
 - singlestep execution
 - cycle-accuracy expansion
 - privileged/exception instructions (`TRAP`, `STOP`, `RTE`)
 
 ## Validation
 
 - `./gradlew --no-daemon test`