### PR TITLE
m68k: step-level register/flag reporting for pipeline debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "oliver/**"
+      - "feature/**"
+      - "chore/**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: Build and test (Java 25)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+      uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      # Wrapper JAR is currently not tracked in this repository, so CI uses system Gradle.
+      - name: Run tests
+        run: gradle --no-daemon test
+
+      - name: Build project
+        run: gradle --no-daemon build

--- a/src/main/java/com/JMPE/bus/Rom.java
+++ b/src/main/java/com/JMPE/bus/Rom.java
@@ -1,4 +1,74 @@
 package com.JMPE.bus;
 
-public class Rom {
+import java.util.Arrays;
+
+/**
+ * Read-only memory region mapped into the emulator address space.
+ * <p>
+ * ROM bytes are immutable after construction so accidental writes fail fast.
+ */
+public final class Rom {
+    private final int baseAddress;
+    private final byte[] bytes;
+
+    public Rom(int baseAddress, byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            throw new IllegalArgumentException("ROM bytes must not be null or empty");
+        }
+        this.baseAddress = baseAddress;
+        this.bytes = Arrays.copyOf(bytes, bytes.length);
+    }
+
+    public int baseAddress() {
+        return baseAddress;
+    }
+
+    public int size() {
+        return bytes.length;
+    }
+
+    public boolean contains(int address) {
+        long offset = Integer.toUnsignedLong(address) - Integer.toUnsignedLong(baseAddress);
+        return offset >= 0 && offset < bytes.length;
+    }
+
+    public int readByte(int address) {
+        return Byte.toUnsignedInt(bytes[offsetFor(address, 1)]);
+    }
+
+    public int readWord(int address) {
+        int offset = offsetFor(address, 2);
+        return (Byte.toUnsignedInt(bytes[offset]) << 8)
+            | Byte.toUnsignedInt(bytes[offset + 1]);
+    }
+
+    public long readLong(int address) {
+        int offset = offsetFor(address, 4);
+        return ((long) Byte.toUnsignedInt(bytes[offset]) << 24)
+            | ((long) Byte.toUnsignedInt(bytes[offset + 1]) << 16)
+            | ((long) Byte.toUnsignedInt(bytes[offset + 2]) << 8)
+            | Byte.toUnsignedInt(bytes[offset + 3]);
+    }
+
+    /**
+     * ROM is immutable by design; writes should be routed to RAM/MMIO regions instead.
+     */
+    public void writeByte(int address, int value) {
+        throw new UnsupportedOperationException(
+            "Cannot write to ROM at address 0x" + Integer.toHexString(address));
+    }
+
+    public byte[] copyBytes() {
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+
+    private int offsetFor(int address, int width) {
+        long start = Integer.toUnsignedLong(address) - Integer.toUnsignedLong(baseAddress);
+        long endExclusive = start + width;
+        if (start < 0 || endExclusive > bytes.length) {
+            throw new IndexOutOfBoundsException(
+                "ROM access out of bounds at address 0x" + Integer.toHexString(address));
+        }
+        return (int) start;
+    }
 }

--- a/src/main/java/com/JMPE/bus/Rom.java
+++ b/src/main/java/com/JMPE/bus/Rom.java
@@ -8,6 +8,10 @@ import java.util.Arrays;
  * ROM bytes are immutable after construction so accidental writes fail fast.
  */
 public final class Rom {
+    private static final int RESET_STACK_POINTER_OFFSET = 0;
+    private static final int RESET_PROGRAM_COUNTER_OFFSET = 4;
+    private static final int RESET_VECTOR_BYTES = 8;
+
     private final int baseAddress;
     private final byte[] bytes;
 
@@ -51,6 +55,22 @@ public final class Rom {
     }
 
     /**
+     * Reads the initial supervisor stack pointer from vector table offset 0x000000.
+     */
+    public int initialSupervisorStackPointer() {
+        ensureHasResetVectors();
+        return (int) readLong(baseAddress + RESET_STACK_POINTER_OFFSET);
+    }
+
+    /**
+     * Reads the initial program counter from vector table offset 0x000004.
+     */
+    public int initialProgramCounter() {
+        ensureHasResetVectors();
+        return (int) readLong(baseAddress + RESET_PROGRAM_COUNTER_OFFSET);
+    }
+
+    /**
      * ROM is immutable by design; writes should be routed to RAM/MMIO regions instead.
      */
     public void writeByte(int address, int value) {
@@ -70,5 +90,11 @@ public final class Rom {
                 "ROM access out of bounds at address 0x" + Integer.toHexString(address));
         }
         return (int) start;
+    }
+
+    private void ensureHasResetVectors() {
+        if (bytes.length < RESET_VECTOR_BYTES) {
+            throw new IllegalStateException("ROM must contain at least 8 bytes for reset vectors");
+        }
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -1,23 +1,61 @@
 package com.JMPE.cpu.m68k;
 
+import com.JMPE.bus.Rom;
+
 /**
  * Minimal CPU shell used to wire core components during early emulator milestones.
  */
 public final class M68kCpu {
+    private static final int RESET_INTERRUPT_MASK = 7;
+
+    private final Registers registers;
     private final StatusRegister statusRegister;
 
     public M68kCpu() {
-        this(new StatusRegister());
+        this(new Registers(), new StatusRegister());
     }
 
     public M68kCpu(StatusRegister statusRegister) {
+        this(new Registers(), statusRegister);
+    }
+
+    public M68kCpu(Registers registers, StatusRegister statusRegister) {
+        if (registers == null) {
+            throw new IllegalArgumentException("registers must not be null");
+        }
         if (statusRegister == null) {
             throw new IllegalArgumentException("statusRegister must not be null");
         }
+        this.registers = registers;
         this.statusRegister = statusRegister;
+    }
+
+    public Registers registers() {
+        return registers;
     }
 
     public StatusRegister statusRegister() {
         return statusRegister;
+    }
+
+    /**
+     * Applies 68000 reset bootstrap state from ROM vectors.
+     * <p>
+     * On reset, the CPU loads SSP and PC from vector table offsets 0 and 4, enters supervisor mode,
+     * clears trace, and masks interrupts to level 7.
+     * </p>
+     */
+    public void resetFromRom(Rom rom) {
+        if (rom == null) {
+            throw new IllegalArgumentException("rom must not be null");
+        }
+
+        registers.setStackPointer(rom.initialSupervisorStackPointer());
+        registers.setProgramCounter(rom.initialProgramCounter());
+
+        statusRegister.setRawValue(0);
+        statusRegister.setSupervisor(true);
+        statusRegister.setTrace(false);
+        statusRegister.setInterruptMask(RESET_INTERRUPT_MASK);
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -2,6 +2,9 @@ package com.JMPE.cpu.m68k;
 
 import com.JMPE.bus.Rom;
 
+import java.util.Objects;
+import java.util.function.Consumer;
+
 /**
  * Minimal CPU shell used to wire core components during early emulator milestones.
  */
@@ -57,5 +60,172 @@ public final class M68kCpu {
         statusRegister.setSupervisor(true);
         statusRegister.setTrace(false);
         statusRegister.setInterruptMask(RESET_INTERRUPT_MASK);
+    }
+
+    /**
+     * Executes one decoded instruction callback, producing a deterministic register/flag report.
+     *
+     * <p>
+     * This is intentionally narrow and focused on current pipeline needs: it snapshots visible CPU
+     * state before and after the step, emits one scan-friendly log line, and rethrows failures so CI
+     * still fails fast while preserving diagnostics.
+     * </p>
+     */
+    public StepReport executeStepWithReport(String instructionName,
+                                            StepExecutor stepExecutor,
+                                            Consumer<String> reporter) {
+        Objects.requireNonNull(instructionName, "instructionName must not be null");
+        Objects.requireNonNull(stepExecutor, "stepExecutor must not be null");
+        Objects.requireNonNull(reporter, "reporter must not be null");
+
+        StepSnapshot before = StepSnapshot.capture(registers, statusRegister);
+        try {
+            stepExecutor.execute();
+            StepSnapshot after = StepSnapshot.capture(registers, statusRegister);
+            StepReport report = StepReport.success(instructionName, before, after);
+            reporter.accept(report.toLogLine());
+            return report;
+        } catch (RuntimeException exception) {
+            StepSnapshot after = StepSnapshot.capture(registers, statusRegister);
+            StepReport report = StepReport.failure(instructionName, before, after, exception.getMessage());
+            reporter.accept(report.toLogLine());
+            throw exception;
+        }
+    }
+
+    public StepReport executeStepWithConsoleReport(String instructionName, StepExecutor stepExecutor) {
+        return executeStepWithReport(instructionName, stepExecutor, System.out::println);
+    }
+
+    @FunctionalInterface
+    public interface StepExecutor {
+        void execute();
+    }
+
+    public static final class StepReport {
+        private final String instructionName;
+        private final boolean success;
+        private final StepSnapshot before;
+        private final StepSnapshot after;
+        private final String errorMessage;
+
+        private StepReport(String instructionName,
+                           boolean success,
+                           StepSnapshot before,
+                           StepSnapshot after,
+                           String errorMessage) {
+            this.instructionName = instructionName;
+            this.success = success;
+            this.before = before;
+            this.after = after;
+            this.errorMessage = errorMessage;
+        }
+
+        static StepReport success(String instructionName, StepSnapshot before, StepSnapshot after) {
+            return new StepReport(instructionName, true, before, after, null);
+        }
+
+        static StepReport failure(String instructionName,
+                                  StepSnapshot before,
+                                  StepSnapshot after,
+                                  String errorMessage) {
+            return new StepReport(instructionName, false, before, after, errorMessage);
+        }
+
+        public boolean success() {
+            return success;
+        }
+
+        public StepSnapshot before() {
+            return before;
+        }
+
+        public StepSnapshot after() {
+            return after;
+        }
+
+        public String toLogLine() {
+            String status = success ? "OK" : "ERR";
+            String error = success ? "" : " error=\"" + (errorMessage == null ? "<no-message>" : errorMessage) + "\"";
+            return "[m68k-step] "
+                + status
+                + " op=" + instructionName
+                + " pc=" + formatHex(before.programCounter()) + "->" + formatHex(after.programCounter())
+                + " sr=" + formatWord(before.statusRegister()) + "(" + formatFlags(before.conditionCodeRegister()) + ")"
+                + "->" + formatWord(after.statusRegister()) + "(" + formatFlags(after.conditionCodeRegister()) + ")"
+                + " d0=" + formatHex(before.dataRegister(0)) + "->" + formatHex(after.dataRegister(0))
+                + " a7=" + formatHex(before.addressRegister(Registers.STACK_POINTER_REGISTER))
+                + "->" + formatHex(after.addressRegister(Registers.STACK_POINTER_REGISTER))
+                + error;
+        }
+
+        private static String formatFlags(int ccr) {
+            return "X=" + bit(ccr, 4)
+                + ",N=" + bit(ccr, 3)
+                + ",Z=" + bit(ccr, 2)
+                + ",V=" + bit(ccr, 1)
+                + ",C=" + bit(ccr, 0);
+        }
+
+        private static int bit(int value, int bitIndex) {
+            return (value >>> bitIndex) & 1;
+        }
+
+        private static String formatHex(int value) {
+            return String.format("0x%08X", value);
+        }
+
+        private static String formatWord(int value) {
+            return String.format("0x%04X", value & 0xFFFF);
+        }
+    }
+
+    public static final class StepSnapshot {
+        private final int[] dataRegisters;
+        private final int[] addressRegisters;
+        private final int programCounter;
+        private final int statusRegister;
+
+        private StepSnapshot(int[] dataRegisters, int[] addressRegisters, int programCounter, int statusRegister) {
+            this.dataRegisters = dataRegisters;
+            this.addressRegisters = addressRegisters;
+            this.programCounter = programCounter;
+            this.statusRegister = statusRegister;
+        }
+
+        static StepSnapshot capture(Registers registers, StatusRegister statusRegister) {
+            return new StepSnapshot(
+                registers.copyDataRegisters(),
+                registers.copyAddressRegisters(),
+                registers.programCounter(),
+                statusRegister.rawValue()
+            );
+        }
+
+        public int dataRegister(int index) {
+            if (index < 0 || index >= Registers.DATA_REGISTER_COUNT) {
+                throw new IllegalArgumentException("Invalid data register index D" + index);
+            }
+            return dataRegisters[index];
+        }
+
+        public int addressRegister(int index) {
+            if (index < 0 || index >= Registers.ADDRESS_REGISTER_COUNT) {
+                throw new IllegalArgumentException("Invalid address register index A" + index);
+            }
+            return addressRegisters[index];
+        }
+
+        public int programCounter() {
+            return programCounter;
+        }
+
+        public int statusRegister() {
+            return statusRegister;
+        }
+
+        public int conditionCodeRegister() {
+            return statusRegister & 0xFF;
+        }
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -1,4 +1,23 @@
 package com.JMPE.cpu.m68k;
 
-public class M68kCpu {
+/**
+ * Minimal CPU shell used to wire core components during early emulator milestones.
+ */
+public final class M68kCpu {
+    private final StatusRegister statusRegister;
+
+    public M68kCpu() {
+        this(new StatusRegister());
+    }
+
+    public M68kCpu(StatusRegister statusRegister) {
+        if (statusRegister == null) {
+            throw new IllegalArgumentException("statusRegister must not be null");
+        }
+        this.statusRegister = statusRegister;
+    }
+
+    public StatusRegister statusRegister() {
+        return statusRegister;
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/Registers.java
+++ b/src/main/java/com/JMPE/cpu/m68k/Registers.java
@@ -1,4 +1,75 @@
 package com.JMPE.cpu.m68k;
 
-public class Registers {
+import java.util.Arrays;
+
+/**
+ * Motorola 68000 programmer-visible register file.
+ * <p>
+ * The 68000 exposes eight data registers (D0-D7), eight address registers (A0-A7),
+ * and a 32-bit program counter. This model provides explicit typed accessors with
+ * defensive index checks so decoder/execution code can fail fast on invalid register ids.
+ * </p>
+ */
+public final class Registers {
+    public static final int DATA_REGISTER_COUNT = 8;
+    public static final int ADDRESS_REGISTER_COUNT = 8;
+    public static final int STACK_POINTER_REGISTER = 7;
+
+    private final int[] dataRegisters = new int[DATA_REGISTER_COUNT];
+    private final int[] addressRegisters = new int[ADDRESS_REGISTER_COUNT];
+    private int programCounter;
+
+    public int data(int index) {
+        return dataRegisters[validateDataIndex(index)];
+    }
+
+    public void setData(int index, int value) {
+        dataRegisters[validateDataIndex(index)] = value;
+    }
+
+    public int address(int index) {
+        return addressRegisters[validateAddressIndex(index)];
+    }
+
+    public void setAddress(int index, int value) {
+        addressRegisters[validateAddressIndex(index)] = value;
+    }
+
+    public int stackPointer() {
+        return addressRegisters[STACK_POINTER_REGISTER];
+    }
+
+    public void setStackPointer(int value) {
+        addressRegisters[STACK_POINTER_REGISTER] = value;
+    }
+
+    public int programCounter() {
+        return programCounter;
+    }
+
+    public void setProgramCounter(int value) {
+        programCounter = value;
+    }
+
+    public int[] copyDataRegisters() {
+        return Arrays.copyOf(dataRegisters, DATA_REGISTER_COUNT);
+    }
+
+    public int[] copyAddressRegisters() {
+        return Arrays.copyOf(addressRegisters, ADDRESS_REGISTER_COUNT);
+    }
+
+    private int validateDataIndex(int index) {
+        if (index < 0 || index >= DATA_REGISTER_COUNT) {
+            throw new IllegalArgumentException("Invalid data register index D" + index);
+        }
+        return index;
+    }
+
+    private int validateAddressIndex(int index) {
+        if (index < 0 || index >= ADDRESS_REGISTER_COUNT) {
+            throw new IllegalArgumentException("Invalid address register index A" + index);
+        }
+        return index;
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/StatusRegister.java
+++ b/src/main/java/com/JMPE/cpu/m68k/StatusRegister.java
@@ -1,5 +1,11 @@
 package com.JMPE.cpu.m68k;
 
+import com.JMPE.cpu.m68k.instructions.arithmetic.Add;
+import com.JMPE.cpu.m68k.instructions.arithmetic.Addq;
+import com.JMPE.cpu.m68k.instructions.arithmetic.Sub;
+import com.JMPE.cpu.m68k.instructions.arithmetic.Subq;
+import com.JMPE.cpu.m68k.instructions.data.Move;
+
 /**
  * Motorola 68000 status register model.
  * <p>
@@ -12,9 +18,14 @@ public final class StatusRegister {
     private static final int ZERO_BIT = 2;
     private static final int NEGATIVE_BIT = 3;
     private static final int EXTEND_BIT = 4;
+    private static final int INTERRUPT_MASK_SHIFT = 8;
+    private static final int INTERRUPT_MASK_BITS = 0b111;
     private static final int SUPERVISOR_BIT = 13;
+    private static final int TRACE_BIT = 15;
 
     private int value;
+    private final ArithmeticConditionCodes arithmeticConditionCodes = new ArithmeticConditionCodes();
+    private final MoveConditionCodes moveConditionCodes = new MoveConditionCodes();
 
     public int rawValue() {
         return value & 0xFFFF;
@@ -30,6 +41,18 @@ public final class StatusRegister {
 
     public void setConditionCodeRegister(int ccr) {
         value = (rawValue() & 0xFF00) | (ccr & 0xFF);
+    }
+
+    public int interruptMask() {
+        return (rawValue() >>> INTERRUPT_MASK_SHIFT) & INTERRUPT_MASK_BITS;
+    }
+
+    public void setInterruptMask(int level) {
+        if (level < 0 || level > INTERRUPT_MASK_BITS) {
+            throw new IllegalArgumentException("interrupt mask level must be in range 0..7");
+        }
+        value = (rawValue() & ~(INTERRUPT_MASK_BITS << INTERRUPT_MASK_SHIFT))
+            | (level << INTERRUPT_MASK_SHIFT);
     }
 
     public boolean isCarrySet() {
@@ -78,6 +101,40 @@ public final class StatusRegister {
 
     public void setSupervisor(boolean set) {
         setBit(SUPERVISOR_BIT, set);
+    }
+
+    public boolean isTraceSet() {
+        return isBitSet(TRACE_BIT);
+    }
+
+    public void setTrace(boolean set) {
+        setBit(TRACE_BIT, set);
+    }
+
+    /**
+     * CCR adapter for MOVE/CMP-like helpers that only update N/Z/V/C.
+     */
+    public Move.ConditionCodes moveConditionCodes() {
+        return moveConditionCodes;
+    }
+
+    /**
+     * CCR adapter for arithmetic helpers that must also set X equal to carry/borrow.
+     */
+    public Add.ConditionCodes addConditionCodes() {
+        return arithmeticConditionCodes;
+    }
+
+    public Addq.ConditionCodes addqConditionCodes() {
+        return arithmeticConditionCodes;
+    }
+
+    public Sub.ConditionCodes subConditionCodes() {
+        return arithmeticConditionCodes;
+    }
+
+    public Subq.ConditionCodes subqConditionCodes() {
+        return arithmeticConditionCodes;
     }
 
     public void updateAddFlags(long source, long destination, long result, int bits) {
@@ -142,5 +199,55 @@ public final class StatusRegister {
             case 32 -> 0x8000_0000L;
             default -> throw new IllegalArgumentException("Unsupported operand width: " + bits);
         };
+    }
+
+    private final class MoveConditionCodes implements Move.ConditionCodes {
+        @Override
+        public void setNegative(boolean value) {
+            StatusRegister.this.setNegative(value);
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            StatusRegister.this.setZero(value);
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            StatusRegister.this.setOverflow(value);
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            StatusRegister.this.setCarry(value);
+        }
+    }
+
+    private final class ArithmeticConditionCodes
+        implements Add.ConditionCodes, Addq.ConditionCodes, Sub.ConditionCodes, Subq.ConditionCodes {
+        @Override
+        public void setNegative(boolean value) {
+            StatusRegister.this.setNegative(value);
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            StatusRegister.this.setZero(value);
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            StatusRegister.this.setOverflow(value);
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            StatusRegister.this.setCarry(value);
+        }
+
+        @Override
+        public void setExtend(boolean value) {
+            StatusRegister.this.setExtend(value);
+        }
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/StatusRegister.java
+++ b/src/main/java/com/JMPE/cpu/m68k/StatusRegister.java
@@ -1,4 +1,146 @@
 package com.JMPE.cpu.m68k;
 
-public class StatusRegister {
+/**
+ * Motorola 68000 status register model.
+ * <p>
+ * This class focuses on stable bit helpers and arithmetic-flag updates so instruction
+ * implementations can reuse one precise source of truth.
+ */
+public final class StatusRegister {
+    private static final int CARRY_BIT = 0;
+    private static final int OVERFLOW_BIT = 1;
+    private static final int ZERO_BIT = 2;
+    private static final int NEGATIVE_BIT = 3;
+    private static final int EXTEND_BIT = 4;
+    private static final int SUPERVISOR_BIT = 13;
+
+    private int value;
+
+    public int rawValue() {
+        return value & 0xFFFF;
+    }
+
+    public void setRawValue(int rawValue) {
+        this.value = rawValue & 0xFFFF;
+    }
+
+    public int conditionCodeRegister() {
+        return rawValue() & 0xFF;
+    }
+
+    public void setConditionCodeRegister(int ccr) {
+        value = (rawValue() & 0xFF00) | (ccr & 0xFF);
+    }
+
+    public boolean isCarrySet() {
+        return isBitSet(CARRY_BIT);
+    }
+
+    public void setCarry(boolean set) {
+        setBit(CARRY_BIT, set);
+    }
+
+    public boolean isOverflowSet() {
+        return isBitSet(OVERFLOW_BIT);
+    }
+
+    public void setOverflow(boolean set) {
+        setBit(OVERFLOW_BIT, set);
+    }
+
+    public boolean isZeroSet() {
+        return isBitSet(ZERO_BIT);
+    }
+
+    public void setZero(boolean set) {
+        setBit(ZERO_BIT, set);
+    }
+
+    public boolean isNegativeSet() {
+        return isBitSet(NEGATIVE_BIT);
+    }
+
+    public void setNegative(boolean set) {
+        setBit(NEGATIVE_BIT, set);
+    }
+
+    public boolean isExtendSet() {
+        return isBitSet(EXTEND_BIT);
+    }
+
+    public void setExtend(boolean set) {
+        setBit(EXTEND_BIT, set);
+    }
+
+    public boolean isSupervisorSet() {
+        return isBitSet(SUPERVISOR_BIT);
+    }
+
+    public void setSupervisor(boolean set) {
+        setBit(SUPERVISOR_BIT, set);
+    }
+
+    public void updateAddFlags(long source, long destination, long result, int bits) {
+        long mask = maskFor(bits);
+        long signBit = signBitFor(bits);
+        long src = source & mask;
+        long dst = destination & mask;
+        long res = result & mask;
+
+        boolean carry = (src + dst) > mask;
+        boolean overflow = ((~(dst ^ src) & (dst ^ res)) & signBit) != 0;
+
+        setCarry(carry);
+        setExtend(carry);
+        setOverflow(overflow);
+        setZero(res == 0);
+        setNegative((res & signBit) != 0);
+    }
+
+    public void updateSubFlags(long source, long destination, long result, int bits) {
+        long mask = maskFor(bits);
+        long signBit = signBitFor(bits);
+        long src = source & mask;
+        long dst = destination & mask;
+        long res = result & mask;
+
+        boolean borrow = dst < src;
+        boolean overflow = (((dst ^ src) & (dst ^ res)) & signBit) != 0;
+
+        setCarry(borrow);
+        setExtend(borrow);
+        setOverflow(overflow);
+        setZero(res == 0);
+        setNegative((res & signBit) != 0);
+    }
+
+    private boolean isBitSet(int bit) {
+        return (rawValue() & (1 << bit)) != 0;
+    }
+
+    private void setBit(int bit, boolean set) {
+        if (set) {
+            value = rawValue() | (1 << bit);
+            return;
+        }
+        value = rawValue() & ~(1 << bit);
+    }
+
+    private long maskFor(int bits) {
+        return switch (bits) {
+            case 8 -> 0xFFL;
+            case 16 -> 0xFFFFL;
+            case 32 -> 0xFFFF_FFFFL;
+            default -> throw new IllegalArgumentException("Unsupported operand width: " + bits);
+        };
+    }
+
+    private long signBitFor(int bits) {
+        return switch (bits) {
+            case 8 -> 0x80L;
+            case 16 -> 0x8000L;
+            case 32 -> 0x8000_0000L;
+            default -> throw new IllegalArgumentException("Unsupported operand width: " + bits);
+        };
+    }
 }

--- a/src/main/java/com/JMPE/machine/MacPlusMachine.java
+++ b/src/main/java/com/JMPE/machine/MacPlusMachine.java
@@ -1,4 +1,40 @@
 package com.JMPE.machine;
 
-public class MacPlusMachine {
+import com.JMPE.bus.Rom;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.util.RomLoader;
+
+/**
+ * Coarse machine composition entry point for integration tests.
+ */
+public final class MacPlusMachine {
+    private final Rom rom;
+    private final M68kCpu cpu;
+
+    public MacPlusMachine(Rom rom) {
+        this(rom, new M68kCpu());
+    }
+
+    public MacPlusMachine(Rom rom, M68kCpu cpu) {
+        if (rom == null) {
+            throw new IllegalArgumentException("rom must not be null");
+        }
+        if (cpu == null) {
+            throw new IllegalArgumentException("cpu must not be null");
+        }
+        this.rom = rom;
+        this.cpu = cpu;
+    }
+
+    public static MacPlusMachine fromRomBytes(byte[] romBytes, int baseAddress) {
+        return new MacPlusMachine(RomLoader.fromBytes(romBytes, baseAddress));
+    }
+
+    public Rom rom() {
+        return rom;
+    }
+
+    public M68kCpu cpu() {
+        return cpu;
+    }
 }

--- a/src/main/java/com/JMPE/machine/MacPlusMachine.java
+++ b/src/main/java/com/JMPE/machine/MacPlusMachine.java
@@ -24,6 +24,7 @@ public final class MacPlusMachine {
         }
         this.rom = rom;
         this.cpu = cpu;
+        this.cpu.resetFromRom(rom);
     }
 
     public static MacPlusMachine fromRomBytes(byte[] romBytes, int baseAddress) {

--- a/src/main/java/com/JMPE/util/RomLoader.java
+++ b/src/main/java/com/JMPE/util/RomLoader.java
@@ -1,4 +1,32 @@
 package com.JMPE.util;
 
-public class RomLoader {
+import com.JMPE.bus.Rom;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Centralized ROM loading and light validation for 68k boot requirements.
+ */
+public final class RomLoader {
+    private static final int MIN_RESET_VECTOR_BYTES = 8;
+
+    private RomLoader() {
+    }
+
+    public static Rom load(Path romPath) throws IOException {
+        return load(romPath, 0x0000_0000);
+    }
+
+    public static Rom load(Path romPath, int baseAddress) throws IOException {
+        return fromBytes(Files.readAllBytes(romPath), baseAddress);
+    }
+
+    public static Rom fromBytes(byte[] bytes, int baseAddress) {
+        if (bytes == null || bytes.length < MIN_RESET_VECTOR_BYTES) {
+            throw new IllegalArgumentException(
+                "ROM must contain at least 8 bytes for initial SSP and PC vectors");
+        }
+        return new Rom(baseAddress, bytes);
+    }
 }

--- a/src/main/java/com/JMPE/util/RomLoader.java
+++ b/src/main/java/com/JMPE/util/RomLoader.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
  */
 public final class RomLoader {
     private static final int MIN_RESET_VECTOR_BYTES = 8;
+    private static final int WORD_BYTES = 2;
 
     private RomLoader() {
     }
@@ -26,6 +27,12 @@ public final class RomLoader {
         if (bytes == null || bytes.length < MIN_RESET_VECTOR_BYTES) {
             throw new IllegalArgumentException(
                 "ROM must contain at least 8 bytes for initial SSP and PC vectors");
+        }
+        if ((bytes.length % WORD_BYTES) != 0) {
+            throw new IllegalArgumentException("ROM length must be even for 16-bit 68000 bus access");
+        }
+        if ((baseAddress & 1) != 0) {
+            throw new IllegalArgumentException("ROM base address must be word-aligned");
         }
         return new Rom(baseAddress, bytes);
     }

--- a/src/test/java/com/JMPE/bus/RomTest.java
+++ b/src/test/java/com/JMPE/bus/RomTest.java
@@ -28,4 +28,25 @@ class RomTest {
         assertThrows(IndexOutOfBoundsException.class, () -> rom.readWord(0x0000_0003));
         assertThrows(UnsupportedOperationException.class, () -> rom.writeByte(0x0000_0000, 0xFF));
     }
+
+    @Test
+    void decodesResetVectors() {
+        Rom rom = new Rom(0x0040_0000, new byte[] {
+            0x00, 0x00, 0x20, 0x00,
+            0x00, 0x40, 0x01, 0x00
+        });
+
+        assertEquals(0x0000_2000, rom.initialSupervisorStackPointer());
+        assertEquals(0x0040_0100, rom.initialProgramCounter());
+    }
+
+    @Test
+    void rejectsResetVectorReadWhenRomIsTooSmall() {
+        Rom rom = new Rom(0x0000_0000, new byte[] {
+            (byte) 0xAA, (byte) 0xBB, (byte) 0xCC, (byte) 0xDD
+        });
+
+        assertThrows(IllegalStateException.class, rom::initialSupervisorStackPointer);
+        assertThrows(IllegalStateException.class, rom::initialProgramCounter);
+    }
 }

--- a/src/test/java/com/JMPE/bus/RomTest.java
+++ b/src/test/java/com/JMPE/bus/RomTest.java
@@ -1,0 +1,31 @@
+package com.JMPE.bus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RomTest {
+    @Test
+    void readsBigEndianValuesFromMappedAddresses() {
+        Rom rom = new Rom(0x0040_0000, new byte[] {
+            (byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78
+        });
+
+        assertEquals(0x12, rom.readByte(0x0040_0000));
+        assertEquals(0x1234, rom.readWord(0x0040_0000));
+        assertEquals(0x1234_5678L, rom.readLong(0x0040_0000));
+        assertTrue(rom.contains(0x0040_0001));
+    }
+
+    @Test
+    void rejectsOutOfBoundsReadAndAllWrites() {
+        Rom rom = new Rom(0x0000_0000, new byte[] {
+            (byte) 0xAA, (byte) 0xBB, (byte) 0xCC, (byte) 0xDD
+        });
+
+        assertThrows(IndexOutOfBoundsException.class, () -> rom.readWord(0x0000_0003));
+        assertThrows(UnsupportedOperationException.class, () -> rom.writeByte(0x0000_0000, 0xFF));
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepReportTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepReportTest.java
@@ -1,0 +1,93 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class M68kCpuStepReportTest {
+    @Test
+    void executeStepWithReportLogsSuccessAndStateTransitions() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0040_0100);
+        cpu.registers().setData(0, 0x0000_0001);
+        cpu.statusRegister().setZero(false);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = cpu.executeStepWithReport(
+            "ADDQ.B #1,D0",
+            () -> {
+                int result = (cpu.registers().data(0) + 1) & 0xFF;
+                cpu.registers().setData(0, result);
+                cpu.registers().setProgramCounter(cpu.registers().programCounter() + 2);
+                cpu.statusRegister().setZero(result == 0);
+                cpu.statusRegister().setNegative((result & 0x80) != 0);
+                cpu.statusRegister().setOverflow(false);
+                cpu.statusRegister().setCarry(false);
+            },
+            logs::add
+        );
+
+        assertTrue(report.success());
+        assertEquals(0x0000_0001, report.before().dataRegister(0));
+        assertEquals(0x0000_0002, report.after().dataRegister(0));
+        assertEquals(0x0040_0100, report.before().programCounter());
+        assertEquals(0x0040_0102, report.after().programCounter());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=ADDQ.B #1,D0"));
+        assertTrue(logs.get(0).contains("pc=0x00400100->0x00400102"));
+    }
+
+    @Test
+    void executeStepWithReportLogsFailureAndRethrows() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0040_0200);
+        cpu.registers().setData(0, 0x1111_1111);
+        List<String> logs = new ArrayList<>();
+
+        IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> cpu.executeStepWithReport("MOVE.B D0,D1", () -> {
+                cpu.registers().setProgramCounter(cpu.registers().programCounter() + 2);
+                throw new IllegalStateException("decode mismatch");
+            }, logs::add)
+        );
+
+        assertEquals("decode mismatch", thrown.getMessage());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] ERR op=MOVE.B D0,D1"));
+        assertTrue(logs.get(0).contains("error=\"decode mismatch\""));
+        assertTrue(logs.get(0).contains("pc=0x00400200->0x00400202"));
+    }
+
+    @Test
+    void executeStepWithReportRejectsNullInputs() {
+        M68kCpu cpu = new M68kCpu();
+        assertThrows(NullPointerException.class, () -> cpu.executeStepWithReport(null, () -> {
+        }, ignored -> {
+        }));
+        assertThrows(NullPointerException.class, () -> cpu.executeStepWithReport("NOP", null, ignored -> {
+        }));
+        assertThrows(NullPointerException.class, () -> cpu.executeStepWithReport("NOP", () -> {
+        }, null));
+    }
+
+    @Test
+    void snapshotValidatesRegisterIndices() {
+        M68kCpu cpu = new M68kCpu();
+        M68kCpu.StepReport report = cpu.executeStepWithReport("NOP", () -> {
+        }, message -> {
+        });
+
+        assertNotNull(report);
+        assertFalse(report.before().statusRegister() != 0 && report.before().conditionCodeRegister() == 0);
+        assertThrows(IllegalArgumentException.class, () -> report.after().dataRegister(8));
+        assertThrows(IllegalArgumentException.class, () -> report.after().addressRegister(8));
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuTest.java
@@ -1,0 +1,35 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.JMPE.bus.Rom;
+import org.junit.jupiter.api.Test;
+
+class M68kCpuTest {
+    @Test
+    void resetFromRomLoadsBootstrapVectorsAndSupervisorState() {
+        M68kCpu cpu = new M68kCpu();
+        Rom rom = new Rom(0x0040_0000, new byte[] {
+            0x00, 0x00, 0x20, 0x00, // initial SSP: 0x00002000
+            0x00, 0x40, 0x01, 0x00  // initial PC:  0x00400100
+        });
+
+        cpu.resetFromRom(rom);
+
+        assertEquals(0x0000_2000, cpu.registers().stackPointer());
+        assertEquals(0x0040_0100, cpu.registers().programCounter());
+        assertTrue(cpu.statusRegister().isSupervisorSet());
+        assertEquals(7, cpu.statusRegister().interruptMask());
+    }
+
+    @Test
+    void rejectsNullDependencies() {
+        assertThrows(IllegalArgumentException.class, () -> new M68kCpu(null, new StatusRegister()));
+        assertThrows(IllegalArgumentException.class, () -> new M68kCpu(new Registers(), null));
+
+        M68kCpu cpu = new M68kCpu();
+        assertThrows(IllegalArgumentException.class, () -> cpu.resetFromRom(null));
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/RegistersTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/RegistersTest.java
@@ -1,0 +1,52 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class RegistersTest {
+    @Test
+    void readsAndWritesDataAddressAndProgramCounter() {
+        Registers registers = new Registers();
+
+        registers.setData(0, 0x1234_5678);
+        registers.setAddress(3, 0x00FF_1000);
+        registers.setProgramCounter(0x0040_0200);
+        registers.setStackPointer(0x0000_2000);
+
+        assertEquals(0x1234_5678, registers.data(0));
+        assertEquals(0x00FF_1000, registers.address(3));
+        assertEquals(0x0000_2000, registers.address(Registers.STACK_POINTER_REGISTER));
+        assertEquals(0x0000_2000, registers.stackPointer());
+        assertEquals(0x0040_0200, registers.programCounter());
+    }
+
+    @Test
+    void validatesDataAndAddressIndices() {
+        Registers registers = new Registers();
+
+        assertThrows(IllegalArgumentException.class, () -> registers.data(-1));
+        assertThrows(IllegalArgumentException.class, () -> registers.data(8));
+        assertThrows(IllegalArgumentException.class, () -> registers.address(-1));
+        assertThrows(IllegalArgumentException.class, () -> registers.address(8));
+    }
+
+    @Test
+    void returnsDefensiveCopiesOfRegisterArrays() {
+        Registers registers = new Registers();
+        registers.setData(1, 0x1111_1111);
+        registers.setAddress(1, 0x2222_2222);
+
+        int[] dataCopy = registers.copyDataRegisters();
+        int[] addressCopy = registers.copyAddressRegisters();
+        dataCopy[1] = 0;
+        addressCopy[1] = 0;
+
+        assertEquals(0x1111_1111, registers.data(1));
+        assertEquals(0x2222_2222, registers.address(1));
+        assertArrayEquals(new int[] {0, 0x1111_1111, 0, 0, 0, 0, 0, 0}, registers.copyDataRegisters());
+        assertArrayEquals(new int[] {0, 0x2222_2222, 0, 0, 0, 0, 0, 0}, registers.copyAddressRegisters());
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/StatusRegisterTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/StatusRegisterTest.java
@@ -1,9 +1,12 @@
 package com.JMPE.cpu.m68k;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.JMPE.cpu.m68k.instructions.arithmetic.Add;
+import com.JMPE.cpu.m68k.instructions.data.Move;
 import org.junit.jupiter.api.Test;
 
 class StatusRegisterTest {
@@ -65,5 +68,60 @@ class StatusRegisterTest {
         StatusRegister sr = new StatusRegister();
         assertThrows(IllegalArgumentException.class, () -> sr.updateAddFlags(1, 1, 2, 24));
         assertThrows(IllegalArgumentException.class, () -> sr.updateSubFlags(1, 1, 0, 64));
+    }
+
+    @Test
+    void writesInterruptMaskAndTraceBit() {
+        StatusRegister sr = new StatusRegister();
+
+        sr.setInterruptMask(7);
+        sr.setTrace(true);
+
+        assertEquals(7, sr.interruptMask());
+        assertTrue(sr.isTraceSet());
+        assertThrows(IllegalArgumentException.class, () -> sr.setInterruptMask(8));
+    }
+
+    @Test
+    void ccrWritePreservesUpperStatusBits() {
+        StatusRegister sr = new StatusRegister();
+        sr.setInterruptMask(5);
+        sr.setSupervisor(true);
+        sr.setConditionCodeRegister(0x001F);
+
+        assertEquals(5, sr.interruptMask());
+        assertTrue(sr.isSupervisorSet());
+        assertEquals(0x1F, sr.conditionCodeRegister());
+    }
+
+    @Test
+    void moveConditionCodesAdapterUpdatesNzvcWithoutTouchingX() {
+        StatusRegister sr = new StatusRegister();
+        sr.setExtend(true);
+
+        Move.updateConditionCodes(0x00, Move.Size.BYTE, sr.moveConditionCodes());
+
+        assertTrue(sr.isZeroSet());
+        assertFalse(sr.isNegativeSet());
+        assertFalse(sr.isOverflowSet());
+        assertFalse(sr.isCarrySet());
+        assertTrue(sr.isExtendSet());
+    }
+
+    @Test
+    void arithmeticConditionCodesAdapterSetsExtendWithCarry() {
+        StatusRegister sr = new StatusRegister();
+        Add.execute(
+            Move.Size.BYTE,
+            () -> 0x01,
+            () -> 0xFF,
+            ignored -> {
+            },
+            sr.addConditionCodes()
+        );
+
+        assertTrue(sr.isCarrySet());
+        assertTrue(sr.isExtendSet());
+        assertTrue(sr.isZeroSet());
     }
 }

--- a/src/test/java/com/JMPE/cpu/m68k/StatusRegisterTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/StatusRegisterTest.java
@@ -1,0 +1,69 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class StatusRegisterTest {
+    @Test
+    void setsAndReadsIndividualFlags() {
+        StatusRegister sr = new StatusRegister();
+
+        sr.setCarry(true);
+        sr.setZero(true);
+        sr.setSupervisor(true);
+
+        assertTrue(sr.isCarrySet());
+        assertTrue(sr.isZeroSet());
+        assertTrue(sr.isSupervisorSet());
+
+        sr.setCarry(false);
+        sr.setZero(false);
+        sr.setSupervisor(false);
+
+        assertFalse(sr.isCarrySet());
+        assertFalse(sr.isZeroSet());
+        assertFalse(sr.isSupervisorSet());
+    }
+
+    @Test
+    void updatesAddFlagsForSignedOverflowAndCarry() {
+        StatusRegister sr = new StatusRegister();
+
+        // 0x7F + 0x01 => 0x80: signed overflow and negative set, no carry.
+        sr.updateAddFlags(0x01, 0x7F, 0x80, 8);
+        assertTrue(sr.isOverflowSet());
+        assertTrue(sr.isNegativeSet());
+        assertFalse(sr.isCarrySet());
+
+        // 0xFF + 0x01 => 0x00: carry/extend and zero set.
+        sr.updateAddFlags(0x01, 0xFF, 0x100, 8);
+        assertTrue(sr.isCarrySet());
+        assertTrue(sr.isExtendSet());
+        assertTrue(sr.isZeroSet());
+    }
+
+    @Test
+    void updatesSubFlagsForBorrowAndSignedOverflow() {
+        StatusRegister sr = new StatusRegister();
+
+        // 0x00 - 0x01 => 0xFF: borrow/carry set and negative set.
+        sr.updateSubFlags(0x01, 0x00, 0xFF, 8);
+        assertTrue(sr.isCarrySet());
+        assertTrue(sr.isNegativeSet());
+        assertFalse(sr.isZeroSet());
+
+        // 0x80 - 0x01 => 0x7F: signed overflow for 8-bit subtraction.
+        sr.updateSubFlags(0x01, 0x80, 0x7F, 8);
+        assertTrue(sr.isOverflowSet());
+    }
+
+    @Test
+    void rejectsUnsupportedOperandWidths() {
+        StatusRegister sr = new StatusRegister();
+        assertThrows(IllegalArgumentException.class, () -> sr.updateAddFlags(1, 1, 2, 24));
+        assertThrows(IllegalArgumentException.class, () -> sr.updateSubFlags(1, 1, 0, 64));
+    }
+}

--- a/src/test/java/com/JMPE/machine/MacPlusMachineTest.java
+++ b/src/test/java/com/JMPE/machine/MacPlusMachineTest.java
@@ -3,6 +3,7 @@ package com.JMPE.machine;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.JMPE.bus.Rom;
 import org.junit.jupiter.api.Test;
@@ -11,19 +12,26 @@ class MacPlusMachineTest {
     @Test
     void buildsMachineFromRomBytes() {
         MacPlusMachine machine = MacPlusMachine.fromRomBytes(new byte[] {
-            0x00, 0x10, 0x00, 0x20, 0x12, 0x34, 0x56, 0x78
+            0x00, 0x00, 0x20, 0x00,
+            0x00, 0x40, 0x01, 0x00
         }, 0x0040_0000);
 
         assertNotNull(machine.cpu());
         assertNotNull(machine.cpu().statusRegister());
         assertEquals(0x0040_0000, machine.rom().baseAddress());
+        assertEquals(0x0000_2000, machine.cpu().registers().stackPointer());
+        assertEquals(0x0040_0100, machine.cpu().registers().programCounter());
+        assertTrue(machine.cpu().statusRegister().isSupervisorSet());
+        assertEquals(7, machine.cpu().statusRegister().interruptMask());
     }
 
     @Test
     void keepsProvidedRomReference() {
-        Rom rom = new Rom(0x0, new byte[] {0, 1, 2, 3, 4, 5, 6, 7});
+        Rom rom = new Rom(0x0, new byte[] {0, 0, 32, 0, 0, 0, 0, 8});
         MacPlusMachine machine = new MacPlusMachine(rom);
 
         assertSame(rom, machine.rom());
+        assertEquals(0x0000_2000, machine.cpu().registers().stackPointer());
+        assertEquals(0x0000_0008, machine.cpu().registers().programCounter());
     }
 }

--- a/src/test/java/com/JMPE/machine/MacPlusMachineTest.java
+++ b/src/test/java/com/JMPE/machine/MacPlusMachineTest.java
@@ -1,0 +1,29 @@
+package com.JMPE.machine;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.JMPE.bus.Rom;
+import org.junit.jupiter.api.Test;
+
+class MacPlusMachineTest {
+    @Test
+    void buildsMachineFromRomBytes() {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(new byte[] {
+            0x00, 0x10, 0x00, 0x20, 0x12, 0x34, 0x56, 0x78
+        }, 0x0040_0000);
+
+        assertNotNull(machine.cpu());
+        assertNotNull(machine.cpu().statusRegister());
+        assertEquals(0x0040_0000, machine.rom().baseAddress());
+    }
+
+    @Test
+    void keepsProvidedRomReference() {
+        Rom rom = new Rom(0x0, new byte[] {0, 1, 2, 3, 4, 5, 6, 7});
+        MacPlusMachine machine = new MacPlusMachine(rom);
+
+        assertSame(rom, machine.rom());
+    }
+}

--- a/src/test/java/com/JMPE/util/RomLoaderTest.java
+++ b/src/test/java/com/JMPE/util/RomLoaderTest.java
@@ -1,0 +1,37 @@
+package com.JMPE.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.JMPE.bus.Rom;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RomLoaderTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadsRomFromDiskAndRespectsBaseAddress() throws IOException {
+        Path romPath = tempDir.resolve("macplus.rom");
+        Files.write(romPath, new byte[] {
+            0x00, 0x10, 0x00, 0x20, 0x12, 0x34, 0x56, 0x78
+        });
+
+        Rom rom = RomLoader.load(romPath, 0x0040_0000);
+
+        assertEquals(0x0040_0000, rom.baseAddress());
+        assertEquals(0x0010, rom.readWord(0x0040_0000));
+        assertEquals(0x1234_5678L, rom.readLong(0x0040_0004));
+    }
+
+    @Test
+    void rejectsRomWithoutResetVectors() {
+        assertThrows(IllegalArgumentException.class, () ->
+            RomLoader.fromBytes(new byte[] {0x01, 0x02, 0x03, 0x04}, 0x0)
+        );
+    }
+}

--- a/src/test/java/com/JMPE/util/RomLoaderTest.java
+++ b/src/test/java/com/JMPE/util/RomLoaderTest.java
@@ -34,4 +34,18 @@ class RomLoaderTest {
             RomLoader.fromBytes(new byte[] {0x01, 0x02, 0x03, 0x04}, 0x0)
         );
     }
+
+    @Test
+    void rejectsMisalignedRomInputs() {
+        assertThrows(IllegalArgumentException.class, () ->
+            RomLoader.fromBytes(new byte[] {
+                0x00, 0x10, 0x00, 0x20, 0x12, 0x34, 0x56
+            }, 0x0)
+        );
+        assertThrows(IllegalArgumentException.class, () ->
+            RomLoader.fromBytes(new byte[] {
+                0x00, 0x10, 0x00, 0x20, 0x12, 0x34, 0x56, 0x78
+            }, 0x1)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
This PR finalizes the register/flag-side CPU visibility work by adding a step-level reporting surface on `M68kCpu`.

### What was added
- `executeStepWithReport(...)` for instruction-step execution with explicit reporter output
- `executeStepWithConsoleReport(...)` convenience wrapper for console logs
- `StepSnapshot` to capture before/after register state (`D`, `A`, `PC`, `SR/CCR`)
- `StepReport` with deterministic log formatting showing:
  - status (`OK`/`ERR`)
  - operation name
  - `PC` transition
  - `SR` / decoded `X,N,Z,V,C`
  - `D0` and `A7` transitions
  - error message on failures

### Behavior
- Success path logs one line and returns a report.
- Failure path logs one line and rethrows (keeps CI fail-fast behavior).

### Tests
- Added `M68kCpuStepReportTest` covering:
  - success reporting path
  - failure reporting + rethrow path
  - null argument validation
  - snapshot register index validation

## Validation
- `gradle --no-daemon test` passed

This keeps scope on the register/flags pipeline support while decoder/instruction wiring continues in parallel.
