### PR TITLE
feat: wire first end-to-end NOP path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ gradle --no-daemon test
 gradle --no-daemon build
 ```
 
+## Helpful trace command
+To see the current end-to-end `NOP` fetch/decode/dispatch/execute flow with only
+the important trace lines:
+
+```bash
+./tools/nop-trace.sh
+```
+
 ## Project layout
 ```text
 src/main/java/com/JMPE/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To see the current end-to-end `NOP` fetch/decode/dispatch/execute flow with only
 the important trace lines:
 
 ```bash
+# Note: ./tools/nop-trace.sh currently expects the Gradle wrapper script (./gradlew).
+# Since the wrapper JAR is not checked in, either generate the wrapper (e.g. `gradle wrapper`)
+# or update the script locally to invoke system Gradle instead of ./gradlew.
 ./tools/nop-trace.sh
 ```
 

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -1,6 +1,11 @@
 package com.JMPE.cpu.m68k;
 
+import com.JMPE.bus.Bus;
 import com.JMPE.bus.Rom;
+import com.JMPE.cpu.m68k.dispatch.DispatchTable;
+import com.JMPE.cpu.m68k.dispatch.Op;
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
 
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -9,6 +14,7 @@ import java.util.function.Consumer;
  * Minimal CPU shell used to wire core components during early emulator milestones.
  */
 public final class M68kCpu {
+    private static final Decoder DECODER = new Decoder();
     private static final int RESET_INTERRUPT_MASK = 7;
 
     private final Registers registers;
@@ -60,6 +66,73 @@ public final class M68kCpu {
         statusRegister.setSupervisor(true);
         statusRegister.setTrace(false);
         statusRegister.setInterruptMask(RESET_INTERRUPT_MASK);
+    }
+
+    /**
+     * Executes one real CPU step through fetch, decode, dispatch, and execute.
+     *
+     * <p>
+     * This is the first non-placeholder execution path in the CPU core. The
+     * method performs the architecturally visible instruction fetch, asks the
+     * stateless {@link Decoder} to decode the fetched opword plus any extension
+     * words, advances PC to {@link DecodedInstruction#nextPc()} once decode
+     * succeeds, and then dispatches to the registered {@link Op} handler for
+     * the decoded opcode.
+     * </p>
+     *
+     * <p>
+     * PC is advanced before the handler runs. This matches the decoder's
+     * contract: by the time execution begins, the instruction stream has
+     * already consumed the opword and all extension words. Instructions that
+     * change control flow later (for example {@code BRA} or {@code RTS}) can
+     * still overwrite PC during execution.
+     * </p>
+     *
+     * @param bus the system bus used for opword fetch and decoder extension-word reads
+     * @param dispatchTable the opcode-to-handler registry for execution
+     * @param reporter sink for one step log line
+     * @return the before/after state report for this step
+     * @throws IllegalInstructionException if decode fails for the fetched opword
+     */
+    public StepReport step(Bus bus,
+                           DispatchTable dispatchTable,
+                           Consumer<String> reporter) throws IllegalInstructionException {
+        Objects.requireNonNull(bus, "bus must not be null");
+        Objects.requireNonNull(dispatchTable, "dispatchTable must not be null");
+        Objects.requireNonNull(reporter, "reporter must not be null");
+
+        StepSnapshot before = StepSnapshot.capture(registers, statusRegister);
+        int opword = bus.readWord(registers.programCounter());
+        String instructionName = String.format("0x%04X", opword & 0xFFFF);
+
+        try {
+            DecodedInstruction decoded = DECODER.decode(opword, bus, registers.programCounter() + 2);
+            instructionName = decoded.opcode().name();
+
+            registers.setProgramCounter(decoded.nextPc());
+            Op handler = dispatchTable.lookup(decoded.opcode());
+            handler.execute(this, decoded);
+
+            StepSnapshot after = StepSnapshot.capture(registers, statusRegister);
+            StepReport report = StepReport.success(instructionName, before, after);
+            reporter.accept(report.toLogLine());
+            return report;
+        } catch (IllegalInstructionException | RuntimeException exception) {
+            StepSnapshot after = StepSnapshot.capture(registers, statusRegister);
+            StepReport report = StepReport.failure(instructionName, before, after, exception.getMessage());
+            reporter.accept(report.toLogLine());
+            throw exception;
+        }
+    }
+
+    public StepReport step(Bus bus, DispatchTable dispatchTable) throws IllegalInstructionException {
+        return step(bus, dispatchTable, ignored -> {
+        });
+    }
+
+    public StepReport stepWithConsoleReport(Bus bus,
+                                            DispatchTable dispatchTable) throws IllegalInstructionException {
+        return step(bus, dispatchTable, System.out::println);
     }
 
     /**

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -111,10 +111,10 @@ public final class M68kCpu {
 
             registers.setProgramCounter(decoded.nextPc());
             Op handler = dispatchTable.lookup(decoded.opcode());
-            handler.execute(this, decoded);
+            int cycles = handler.execute(this, decoded);
 
             StepSnapshot after = StepSnapshot.capture(registers, statusRegister);
-            StepReport report = StepReport.success(instructionName, before, after);
+            StepReport report = StepReport.success(instructionName, before, after, cycles);
             reporter.accept(report.toLogLine());
             return report;
         } catch (IllegalInstructionException | RuntimeException exception) {
@@ -181,28 +181,35 @@ public final class M68kCpu {
         private final StepSnapshot before;
         private final StepSnapshot after;
         private final String errorMessage;
+        private final int cycles;
 
         private StepReport(String instructionName,
                            boolean success,
                            StepSnapshot before,
                            StepSnapshot after,
-                           String errorMessage) {
+                           String errorMessage,
+                           int cycles) {
             this.instructionName = instructionName;
             this.success = success;
             this.before = before;
             this.after = after;
             this.errorMessage = errorMessage;
+            this.cycles = cycles;
+        }
+
+        static StepReport success(String instructionName, StepSnapshot before, StepSnapshot after, int cycles) {
+            return new StepReport(instructionName, true, before, after, null, cycles);
         }
 
         static StepReport success(String instructionName, StepSnapshot before, StepSnapshot after) {
-            return new StepReport(instructionName, true, before, after, null);
+            return new StepReport(instructionName, true, before, after, null, 0);
         }
 
         static StepReport failure(String instructionName,
                                   StepSnapshot before,
                                   StepSnapshot after,
                                   String errorMessage) {
-            return new StepReport(instructionName, false, before, after, errorMessage);
+            return new StepReport(instructionName, false, before, after, errorMessage, 0);
         }
 
         public boolean success() {
@@ -217,12 +224,17 @@ public final class M68kCpu {
             return after;
         }
 
+        public int cycles() {
+            return cycles;
+        }
+
         public String toLogLine() {
             String status = success ? "OK" : "ERR";
             String error = success ? "" : " error=\"" + (errorMessage == null ? "<no-message>" : errorMessage) + "\"";
             return "[m68k-step] "
                 + status
                 + " op=" + instructionName
+                + " cycles=" + cycles
                 + " pc=" + formatHex(before.programCounter()) + "->" + formatHex(after.programCounter())
                 + " sr=" + formatWord(before.statusRegister()) + "(" + formatFlags(before.conditionCodeRegister()) + ")"
                 + "->" + formatWord(after.statusRegister()) + "(" + formatFlags(after.conditionCodeRegister()) + ")"

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchTable.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchTable.java
@@ -1,4 +1,95 @@
 package com.JMPE.cpu.m68k.dispatch;
 
-public class DispatchTable {
+import com.JMPE.cpu.m68k.instructions.Opcode;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Registry mapping decoded {@link Opcode opcodes} to executable {@link Op}
+ * handlers.
+ *
+ * <p>
+ * In this project structure, {@code Decoder} answers "what instruction is
+ * this?", while {@code DispatchTable} answers "which executor handles it?".
+ * Keeping that lookup centralized avoids pushing a growing opcode switch into
+ * {@code M68kCpu} and gives each instruction or instruction family a clear
+ * place to plug into the runtime pipeline.
+ * </p>
+ */
+public final class DispatchTable {
+    private final Map<Opcode, Op> handlers = new EnumMap<>(Opcode.class);
+
+    /**
+     * Creates a dispatch table with the built-in handlers that are currently
+     * available in the runtime.
+     */
+    public DispatchTable() {
+        this(true);
+    }
+
+    private DispatchTable(boolean registerBuiltIns) {
+        if (registerBuiltIns) {
+            registerBuiltIns();
+        }
+    }
+
+    /**
+     * Creates an empty dispatch table.
+     *
+     * <p>
+     * This is mainly useful for focused unit tests where the registration
+     * behavior itself is under test.
+     * </p>
+     */
+    public static DispatchTable empty() {
+        return new DispatchTable(false);
+    }
+
+    /**
+     * Registers the handler for one opcode.
+     *
+     * @throws NullPointerException if {@code opcode} or {@code handler} is null
+     * @throws IllegalStateException if a handler is already registered
+     */
+    public void register(Opcode opcode, Op handler) {
+        Objects.requireNonNull(opcode, "opcode must not be null");
+        Objects.requireNonNull(handler, "handler must not be null");
+
+        Op previous = handlers.putIfAbsent(opcode, handler);
+        if (previous != null) {
+            throw new IllegalStateException("Handler already registered for opcode " + opcode);
+        }
+    }
+
+    /**
+     * Returns the registered handler for the opcode.
+     *
+     * @throws NullPointerException if {@code opcode} is null
+     * @throws IllegalStateException if no handler has been registered
+     */
+    public Op lookup(Opcode opcode) {
+        Objects.requireNonNull(opcode, "opcode must not be null");
+
+        Op handler = handlers.get(opcode);
+        if (handler == null) {
+            throw new IllegalStateException("No handler registered for opcode " + opcode);
+        }
+        return handler;
+    }
+
+    /**
+     * Returns whether the opcode currently has a registered handler.
+     *
+     * @throws NullPointerException if {@code opcode} is null
+     */
+    public boolean hasHandler(Opcode opcode) {
+        Objects.requireNonNull(opcode, "opcode must not be null");
+        return handlers.containsKey(opcode);
+    }
+
+    private void registerBuiltIns() {
+        register(Opcode.NOP, new NopOp());
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/NopOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/NopOp.java
@@ -1,0 +1,57 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.control.Nop;
+
+import java.util.Objects;
+
+/**
+ * Dispatch-layer executor for decoded {@code NOP} instructions.
+ *
+ * <p>
+ * The plain {@link Nop} helper only models the raw instruction semantics:
+ * "do nothing and cost 4 cycles". {@code NopOp} exists one layer above that.
+ * It is the runtime adapter that says "this decoded instruction is a NOP, so
+ * the CPU pipeline should execute the NOP helper here".
+ * </p>
+ *
+ * <p>
+ * Keeping this adapter separate preserves the current project structure:
+ * </p>
+ * <ul>
+ *   <li>{@code Decoder} identifies the instruction and builds a {@link DecodedInstruction}</li>
+ *   <li>{@link DispatchTable} selects the matching {@link Op}</li>
+ *   <li>{@code NopOp} validates the decoded shape and bridges to {@link Nop}</li>
+ *   <li>{@link Nop} stays a small, reusable instruction-semantics helper</li>
+ * </ul>
+ */
+public final class NopOp implements Op {
+    @Override
+    public int execute(M68kCpu cpu, DecodedInstruction decoded) {
+        Objects.requireNonNull(cpu, "cpu must not be null");
+        Objects.requireNonNull(decoded, "decoded must not be null");
+
+        validate(decoded);
+        return Nop.execute();
+    }
+
+    private static void validate(DecodedInstruction decoded) {
+        if (decoded.opcode() != Opcode.NOP) {
+            throw new IllegalArgumentException("NopOp requires opcode NOP but was " + decoded.opcode());
+        }
+        if (!decoded.isUnsized()) {
+            throw new IllegalArgumentException("NOP must be decoded as UNSIZED");
+        }
+        if (!decoded.hasNoSource()) {
+            throw new IllegalArgumentException("NOP must not have a source operand");
+        }
+        if (!decoded.hasNoDestination()) {
+            throw new IllegalArgumentException("NOP must not have a destination operand");
+        }
+        if (decoded.extension() != 0) {
+            throw new IllegalArgumentException("NOP must not carry an extension payload");
+        }
+    }
+}

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/Op.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/Op.java
@@ -1,4 +1,26 @@
 package com.JMPE.cpu.m68k.dispatch;
 
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+
+/**
+ * Executes one already-decoded instruction against live CPU state.
+ *
+ * <p>
+ * The decoder is responsible for turning an opword into a
+ * {@link DecodedInstruction}. An {@code Op} is the next layer: it interprets
+ * that decoded shape and bridges into the helper implementations under
+ * {@code cpu.m68k.instructions}.
+ * </p>
+ */
+@FunctionalInterface
 public interface Op {
+    /**
+     * Executes the decoded instruction and returns the instruction cycle cost.
+     *
+     * @param cpu the CPU state to read and mutate
+     * @param decoded the already-decoded instruction descriptor
+     * @return the execution cycle cost for the instruction
+     */
+    int execute(M68kCpu cpu, DecodedInstruction decoded);
 }

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -1,0 +1,127 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.JMPE.bus.AddressSpace;
+import com.JMPE.bus.Ram;
+import com.JMPE.cpu.m68k.dispatch.DispatchTable;
+import com.JMPE.cpu.m68k.dispatch.Op;
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class M68kCpuStepTest {
+    @Test
+    void stepFetchesDecodesDispatchesAndAdvancesPcForNop() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        cpu.registers().setData(0, 0x1234_5678);
+        cpu.statusRegister().setCarry(true);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = cpu.step(busWithOpword(0x0000_1000, 0x4E71), new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1000, report.before().programCounter());
+        assertEquals(0x0000_1002, report.after().programCounter());
+        assertEquals(0x1234_5678, report.after().dataRegister(0));
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=NOP"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
+    }
+
+    @Test
+    void traceNopPipelineToConsole() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        AddressSpace bus = busWithOpword(0x0000_1000, 0x4E71);
+        DispatchTable dispatchTable = new DispatchTable();
+
+        int fetchedOpword = bus.readWord(cpu.registers().programCounter());
+        System.out.printf("[nop-trace] fetch opword=0x%04X pc=0x%08X%n",
+            fetchedOpword, cpu.registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            fetchedOpword,
+            bus,
+            cpu.registers().programCounter() + 2
+        );
+        System.out.printf("[nop-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        Op handler = dispatchTable.lookup(decoded.opcode());
+        System.out.printf("[nop-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
+
+        M68kCpu.StepReport report = cpu.step(
+            bus,
+            dispatchTable,
+            message -> System.out.println("[nop-trace] execute " + message)
+        );
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
+    }
+
+    @Test
+    void stepLogsAndRethrowsIllegalInstructions() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        List<String> logs = new ArrayList<>();
+
+        IllegalInstructionException thrown = assertThrows(
+            IllegalInstructionException.class,
+            () -> cpu.step(busWithOpword(0x0000_1000, 0x4E74), new DispatchTable(), logs::add)
+        );
+
+        assertTrue(thrown.getMessage().contains("does not correspond to a valid instruction opcode"));
+        assertEquals(0x0000_1000, cpu.registers().programCounter());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] ERR op=0x4E74"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001000"));
+    }
+
+    @Test
+    void stepLogsAndRethrowsMissingHandlerFailures() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        List<String> logs = new ArrayList<>();
+
+        IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> cpu.step(busWithOpword(0x0000_1000, 0x4E71), DispatchTable.empty(), logs::add)
+        );
+
+        assertEquals("No handler registered for opcode NOP", thrown.getMessage());
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] ERR op=NOP"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
+    }
+
+    @Test
+    void stepRejectsNullInputs() {
+        M68kCpu cpu = new M68kCpu();
+        DispatchTable dispatchTable = new DispatchTable();
+        AddressSpace bus = busWithOpword(0x0000_1000, 0x4E71);
+
+        assertThrows(NullPointerException.class, () -> cpu.step(null, dispatchTable, ignored -> {
+        }));
+        assertThrows(NullPointerException.class, () -> cpu.step(bus, null, ignored -> {
+        }));
+        assertThrows(NullPointerException.class, () -> cpu.step(bus, dispatchTable, null));
+    }
+
+    private static AddressSpace busWithOpword(int baseAddress, int opword) {
+        Ram ram = new Ram(baseAddress, 64);
+        AddressSpace bus = new AddressSpace();
+        bus.addRegion(ram);
+        bus.writeWord(baseAddress, opword);
+        return bus;
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -31,8 +31,10 @@ class M68kCpuStepTest {
         assertEquals(0x0000_1002, report.after().programCounter());
         assertEquals(0x1234_5678, report.after().dataRegister(0));
         assertEquals(0x0000_1002, cpu.registers().programCounter());
+        assertEquals(4, report.cycles());
         assertEquals(1, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=NOP"));
+        assertTrue(logs.get(0).contains("cycles=4"));
         assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
     }
 

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/DispatchTableTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/DispatchTableTest.java
@@ -1,0 +1,69 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import org.junit.jupiter.api.Test;
+
+class DispatchTableTest {
+    @Test
+    void providesBuiltInNopHandler() {
+        DispatchTable dispatchTable = new DispatchTable();
+
+        assertTrue(dispatchTable.hasHandler(Opcode.NOP));
+        assertTrue(dispatchTable.lookup(Opcode.NOP) instanceof NopOp);
+    }
+
+    @Test
+    void returnsRegisteredHandlerFromEmptyTable() {
+        DispatchTable dispatchTable = DispatchTable.empty();
+        Op handler = (cpu, decoded) -> 4;
+
+        dispatchTable.register(Opcode.RTS, handler);
+
+        assertSame(handler, dispatchTable.lookup(Opcode.RTS));
+    }
+
+    @Test
+    void tracksWhetherAnOpcodeHasAHandler() {
+        DispatchTable dispatchTable = DispatchTable.empty();
+        Op handler = (cpu, decoded) -> 4;
+
+        assertFalse(dispatchTable.hasHandler(Opcode.RTS));
+        dispatchTable.register(Opcode.RTS, handler);
+        assertTrue(dispatchTable.hasHandler(Opcode.RTS));
+        assertFalse(dispatchTable.hasHandler(Opcode.JSR));
+    }
+
+    @Test
+    void rejectsDuplicateRegistration() {
+        DispatchTable dispatchTable = DispatchTable.empty();
+        Op first = (cpu, decoded) -> 4;
+        Op second = (cpu, decoded) -> 8;
+
+        dispatchTable.register(Opcode.RTS, first);
+
+        assertThrows(IllegalStateException.class, () -> dispatchTable.register(Opcode.RTS, second));
+    }
+
+    @Test
+    void rejectsMissingHandlerLookup() {
+        DispatchTable dispatchTable = DispatchTable.empty();
+
+        assertThrows(IllegalStateException.class, () -> dispatchTable.lookup(Opcode.NOP));
+    }
+
+    @Test
+    void rejectsNullInputs() {
+        DispatchTable dispatchTable = new DispatchTable();
+        Op handler = (cpu, decoded) -> 4;
+
+        assertThrows(NullPointerException.class, () -> dispatchTable.register(null, handler));
+        assertThrows(NullPointerException.class, () -> dispatchTable.register(Opcode.NOP, null));
+        assertThrows(NullPointerException.class, () -> dispatchTable.lookup(null));
+        assertThrows(NullPointerException.class, () -> dispatchTable.hasHandler(null));
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/NopOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/NopOpTest.java
@@ -1,0 +1,109 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.control.Nop;
+import org.junit.jupiter.api.Test;
+
+class NopOpTest {
+    @Test
+    void executesNopWithoutChangingCpuState() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0040_0100);
+        cpu.registers().setData(0, 0x1234_5678);
+        cpu.statusRegister().setCarry(true);
+
+        int cycles = new NopOp().execute(cpu, decodedNop());
+
+        assertEquals(Nop.EXECUTION_CYCLES, cycles);
+        assertEquals(0x0040_0100, cpu.registers().programCounter());
+        assertEquals(0x1234_5678, cpu.registers().data(0));
+        assertEquals(true, cpu.statusRegister().isCarrySet());
+    }
+
+    @Test
+    void rejectsWrongOpcode() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction decoded = new DecodedInstruction(
+            Opcode.RTS,
+            Size.UNSIZED,
+            EffectiveAddress.none(),
+            EffectiveAddress.none(),
+            0,
+            0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new NopOp().execute(cpu, decoded));
+    }
+
+    @Test
+    void rejectsSizedNop() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction decoded = new DecodedInstruction(
+            Opcode.NOP,
+            Size.WORD,
+            EffectiveAddress.none(),
+            EffectiveAddress.none(),
+            0,
+            0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new NopOp().execute(cpu, decoded));
+    }
+
+    @Test
+    void rejectsUnexpectedOperandsOrExtensionPayload() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction withSource = new DecodedInstruction(
+            Opcode.NOP,
+            Size.UNSIZED,
+            EffectiveAddress.immediate(1),
+            EffectiveAddress.none(),
+            0,
+            0x0040_0102
+        );
+        DecodedInstruction withDestination = new DecodedInstruction(
+            Opcode.NOP,
+            Size.UNSIZED,
+            EffectiveAddress.none(),
+            EffectiveAddress.dataReg(0),
+            0,
+            0x0040_0102
+        );
+        DecodedInstruction withExtension = new DecodedInstruction(
+            Opcode.NOP,
+            Size.UNSIZED,
+            EffectiveAddress.none(),
+            EffectiveAddress.none(),
+            1,
+            0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new NopOp().execute(cpu, withSource));
+        assertThrows(IllegalArgumentException.class, () -> new NopOp().execute(cpu, withDestination));
+        assertThrows(IllegalArgumentException.class, () -> new NopOp().execute(cpu, withExtension));
+    }
+
+    @Test
+    void rejectsNullInputs() {
+        assertThrows(NullPointerException.class, () -> new NopOp().execute(null, decodedNop()));
+        assertThrows(NullPointerException.class, () -> new NopOp().execute(new M68kCpu(), null));
+    }
+
+    private static DecodedInstruction decodedNop() {
+        return new DecodedInstruction(
+            Opcode.NOP,
+            Size.UNSIZED,
+            EffectiveAddress.none(),
+            EffectiveAddress.none(),
+            0,
+            0x0040_0102
+        );
+    }
+}

--- a/tools/nop-trace.sh
+++ b/tools/nop-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+./gradlew --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.cpu.m68k.M68kCpuStepTest.traceNopPipelineToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[nop-trace\]|\[m68k-step\]"

--- a/tools/nop-trace.sh
+++ b/tools/nop-trace.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-./gradlew --no-daemon test --rerun-tasks \
+gradle --no-daemon test --rerun-tasks \
   --tests "com.JMPE.cpu.m68k.M68kCpuStepTest.traceNopPipelineToConsole" \
   --info --console=plain 2>&1 | grep -E "\[nop-trace\]|\[m68k-step\]"


### PR DESCRIPTION
Add the first real CPU fetch/decode/dispatch/execute path around NOP, including the dispatch contract, built-in NOP handler, focused step tests, and a small trace helper script.