### PR TITLE
feat: execute TST on data registers

### DIFF
--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchTable.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchTable.java
@@ -91,5 +91,6 @@ public final class DispatchTable {
 
     private void registerBuiltIns() {
         register(Opcode.NOP, new NopOp());
+        register(Opcode.TST, new TstOp());
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/TstOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/TstOp.java
@@ -1,0 +1,65 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.data.Tst;
+
+import java.util.Objects;
+
+/**
+ * Dispatch-layer executor for decoded {@code TST} instructions.
+ *
+ * <p>
+ * The raw {@link Tst} helper only knows how to apply TST semantics to a sized
+ * operand reader and CCR sink. {@code TstOp} is the runtime bridge that
+ * validates the decoded shape and resolves the currently supported operand
+ * form from live CPU state.
+ * </p>
+ *
+ * <p>
+ * This first runtime milestone intentionally supports only data-register-direct
+ * TST forms. That keeps the branch aligned with the current no-RAM execution
+ * goal and avoids widening the runtime before a shared bus-backed
+ * effective-address reader exists.
+ * </p>
+ */
+public final class TstOp implements Op {
+    @Override
+    public int execute(M68kCpu cpu, DecodedInstruction decoded) {
+        Objects.requireNonNull(cpu, "cpu must not be null");
+        Objects.requireNonNull(decoded, "decoded must not be null");
+
+        EffectiveAddress.DataReg destination = validate(decoded);
+        return Tst.execute(
+                decoded.size(),
+                () -> cpu.registers().data(destination.reg()),
+                cpu.statusRegister().moveConditionCodes()
+        );
+    }
+
+    private static EffectiveAddress.DataReg validate(DecodedInstruction decoded) {
+        if (decoded.opcode() != Opcode.TST) {
+            throw new IllegalArgumentException("TstOp requires opcode TST but was " + decoded.opcode());
+        }
+        if (!decoded.size().isSized()) {
+            throw new IllegalArgumentException("TST must be decoded with a sized operand");
+        }
+        if (!decoded.hasNoSource()) {
+            throw new IllegalArgumentException("TST must not have a source operand");
+        }
+        if (decoded.hasNoDestination()) {
+            throw new IllegalArgumentException("TST must have a destination operand");
+        }
+        if (decoded.extension() != 0) {
+            throw new IllegalArgumentException("TST must not carry an extension payload");
+        }
+        if (!(decoded.dst() instanceof EffectiveAddress.DataReg dataRegister)) {
+            throw new IllegalArgumentException(
+                    "TST runtime currently supports data-register-direct destination only but was " + decoded.dst()
+            );
+        }
+        return dataRegister;
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -1,6 +1,7 @@
 package com.JMPE.cpu.m68k;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,6 +69,34 @@ class M68kCpuStepTest {
 
         assertTrue(report.success());
         assertEquals(0x0000_1002, cpu.registers().programCounter());
+    }
+
+    @Test
+    void stepFetchesDecodesDispatchesAndUpdatesFlagsForTstDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        cpu.registers().setData(0, 0x0000_0080);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setZero(true);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = cpu.step(busWithOpword(0x0000_1000, 0x4A00), new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1000, report.before().programCounter());
+        assertEquals(0x0000_1002, report.after().programCounter());
+        assertEquals(0x0000_0080, cpu.registers().data(0));
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
     }
 
     @Test

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/DispatchTableTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/DispatchTableTest.java
@@ -18,6 +18,14 @@ class DispatchTableTest {
     }
 
     @Test
+    void providesBuiltInTstHandler() {
+        DispatchTable dispatchTable = new DispatchTable();
+
+        assertTrue(dispatchTable.hasHandler(Opcode.TST));
+        assertTrue(dispatchTable.lookup(Opcode.TST) instanceof TstOp);
+    }
+
+    @Test
     void returnsRegisteredHandlerFromEmptyTable() {
         DispatchTable dispatchTable = DispatchTable.empty();
         Op handler = (cpu, decoded) -> 4;

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/TstOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/TstOpTest.java
@@ -1,0 +1,119 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.data.Tst;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TstOpTest {
+    @Test
+    void executesTstOnDataRegisterWithoutModifyingTheRegister() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setData(0, 0x0000_0080);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setZero(true);
+
+        int cycles = new TstOp().execute(cpu, decodedTst(Size.BYTE, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Tst.EXECUTION_CYCLES, cycles);
+        assertEquals(0x0000_0080, cpu.registers().data(0));
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    @Test
+    void rejectsWrongOpcodeOrUnsizedDecode() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction wrongOpcode = new DecodedInstruction(
+                Opcode.NOP,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction unsized = new DecodedInstruction(
+                Opcode.TST,
+                Size.UNSIZED,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new TstOp().execute(cpu, wrongOpcode));
+        assertThrows(IllegalArgumentException.class, () -> new TstOp().execute(cpu, unsized));
+    }
+
+    @Test
+    void rejectsUnsupportedOperandsOrExtensionPayload() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction withSource = new DecodedInstruction(
+                Opcode.TST,
+                Size.BYTE,
+                EffectiveAddress.immediate(1),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withNoDestination = new DecodedInstruction(
+                Opcode.TST,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.none(),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withMemoryDestination = new DecodedInstruction(
+                Opcode.TST,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.addrRegInd(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withExtension = new DecodedInstruction(
+                Opcode.TST,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                1,
+                0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new TstOp().execute(cpu, withSource));
+        assertThrows(IllegalArgumentException.class, () -> new TstOp().execute(cpu, withNoDestination));
+        assertThrows(IllegalArgumentException.class, () -> new TstOp().execute(cpu, withMemoryDestination));
+        assertThrows(IllegalArgumentException.class, () -> new TstOp().execute(cpu, withExtension));
+    }
+
+    @Test
+    void rejectsNullInputs() {
+        assertThrows(NullPointerException.class, () -> new TstOp().execute(null, decodedTst(Size.BYTE, EffectiveAddress.dataReg(0))));
+        assertThrows(NullPointerException.class, () -> new TstOp().execute(new M68kCpu(), null));
+    }
+
+    private static DecodedInstruction decodedTst(Size size, EffectiveAddress destination) {
+        return new DecodedInstruction(
+                Opcode.TST,
+                size,
+                EffectiveAddress.none(),
+                destination,
+                0,
+                0x0040_0102
+        );
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/instructions/data/Tst_Test.java
+++ b/src/test/java/com/JMPE/cpu/m68k/instructions/data/Tst_Test.java
@@ -1,0 +1,77 @@
+package com.JMPE.cpu.m68k.instructions.data;
+
+import com.JMPE.cpu.m68k.Size;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Tst_Test {
+    @Test
+    void executeMasksByteOperandAndSetsNegative() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        int cycles = Tst.execute(Size.BYTE, () -> 0x0000_0180, conditionCodes);
+
+        assertAll(
+                () -> assertEquals(Tst.EXECUTION_CYCLES, cycles),
+                () -> assertTrue(conditionCodes.negative),
+                () -> assertFalse(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeSetsZeroForMaskedWordZero() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        Tst.execute(Size.WORD, () -> 0x0001_0000, conditionCodes);
+
+        assertAll(
+                () -> assertFalse(conditionCodes.negative),
+                () -> assertTrue(conditionCodes.zero),
+                () -> assertFalse(conditionCodes.overflow),
+                () -> assertFalse(conditionCodes.carry)
+        );
+    }
+
+    @Test
+    void executeRejectsNullInputs() {
+        TrackingConditionCodes conditionCodes = new TrackingConditionCodes();
+
+        assertThrows(NullPointerException.class, () -> Tst.execute(null, () -> 0, conditionCodes));
+        assertThrows(NullPointerException.class, () -> Tst.execute(Size.BYTE, null, conditionCodes));
+        assertThrows(NullPointerException.class, () -> Tst.execute(Size.BYTE, () -> 0, null));
+    }
+
+    private static final class TrackingConditionCodes implements Move.ConditionCodes {
+        private boolean negative;
+        private boolean zero;
+        private boolean overflow;
+        private boolean carry;
+
+        @Override
+        public void setNegative(boolean value) {
+            negative = value;
+        }
+
+        @Override
+        public void setZero(boolean value) {
+            zero = value;
+        }
+
+        @Override
+        public void setOverflow(boolean value) {
+            overflow = value;
+        }
+
+        @Override
+        public void setCarry(boolean value) {
+            carry = value;
+        }
+    }
+}

--- a/src/test/java/com/JMPE/integration/SmallProgramTest.java
+++ b/src/test/java/com/JMPE/integration/SmallProgramTest.java
@@ -1,6 +1,7 @@
 package com.JMPE.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.JMPE.cpu.m68k.M68kCpu;
@@ -15,11 +16,13 @@ class SmallProgramTest {
     private static final int ROM_BASE = 0x0040_0000;
     private static final int INITIAL_STACK_POINTER = 0x0000_2000;
     private static final int INITIAL_PROGRAM_COUNTER = 0x0040_0100;
-    private static final int NOP_OFFSET = INITIAL_PROGRAM_COUNTER - ROM_BASE;
+    private static final int INSTRUCTION_OFFSET = INITIAL_PROGRAM_COUNTER - ROM_BASE;
+    private static final int NOP = 0x4E71;
+    private static final int TST_B_D0 = 0x4A00;
 
     @Test
     void stepsNopThroughMachineLayer() throws IllegalInstructionException {
-        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleNop(), ROM_BASE);
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(NOP), ROM_BASE);
         List<String> logs = new ArrayList<>();
 
         M68kCpu.StepReport report = machine.step(logs::add);
@@ -36,7 +39,7 @@ class SmallProgramTest {
 
     @Test
     void traceNopThroughMachineLayerToConsole() throws IllegalInstructionException {
-        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleNop(), ROM_BASE);
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(NOP), ROM_BASE);
 
         System.out.printf("[machine-nop-trace] machine romBase=0x%08X bus=%s%n",
             machine.rom().baseAddress(), machine.bus().getClass().getSimpleName());
@@ -59,7 +62,33 @@ class SmallProgramTest {
         assertEquals(4, report.cycles());
     }
 
-    private static byte[] romBytesWithSingleNop() {
+    @Test
+    void stepsTstDataRegisterThroughMachineLayer() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(TST_B_D0), ROM_BASE);
+        machine.cpu().registers().setData(0, 0x0000_0080);
+        machine.cpu().statusRegister().setExtend(true);
+        machine.cpu().statusRegister().setCarry(true);
+        machine.cpu().statusRegister().setOverflow(true);
+        machine.cpu().statusRegister().setZero(true);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = machine.step(logs::add);
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER, report.before().programCounter());
+        assertEquals(INITIAL_PROGRAM_COUNTER + 2, report.after().programCounter());
+        assertEquals(0x0000_0080, machine.cpu().registers().data(0));
+        assertTrue(machine.cpu().statusRegister().isNegativeSet());
+        assertFalse(machine.cpu().statusRegister().isZeroSet());
+        assertFalse(machine.cpu().statusRegister().isOverflowSet());
+        assertFalse(machine.cpu().statusRegister().isCarrySet());
+        assertTrue(machine.cpu().statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
+    }
+
+    private static byte[] romBytesWithSingleInstruction(int opword) {
         byte[] bytes = new byte[0x0200];
 
         bytes[0] = 0x00;
@@ -72,8 +101,8 @@ class SmallProgramTest {
         bytes[6] = 0x01;
         bytes[7] = 0x00;
 
-        bytes[NOP_OFFSET] = 0x4E;
-        bytes[NOP_OFFSET + 1] = 0x71;
+        bytes[INSTRUCTION_OFFSET] = (byte) ((opword >>> 8) & 0xFF);
+        bytes[INSTRUCTION_OFFSET + 1] = (byte) (opword & 0xFF);
         return bytes;
     }
 }


### PR DESCRIPTION
Add the first runtime TST path by wiring a dispatch-layer TstOp for data-register-direct forms, plus helper, CPU-step, and machine-layer coverage.