### PR TITLE
test: add TST trace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,20 @@ gradle --no-daemon build
 ```
 
 ## Helpful trace commands
-To see the current end-to-end `NOP` flow with only the important trace lines:
+To see the current end-to-end trace flows with only the important lines:
 
 ```bash
-# CPU-layer trace
+# CPU-layer NOP trace
 ./tools/nop-trace.sh
 
-# Machine-layer trace
+# Machine-layer NOP trace
 ./tools/machine-nop-trace.sh
+
+# CPU-layer TST.B D0 trace
+./tools/tst-trace.sh
+
+# Machine-layer TST.B D0 trace
+./tools/machine-tst-trace.sh
 ```
 
 ## Project layout

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -17,6 +17,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 class M68kCpuStepTest {
+    private static final int TST_B_D0 = 0x4A00;
+    private static final int TST_NEGATIVE_BYTE = 0x0000_0080;
+
     @Test
     void stepFetchesDecodesDispatchesAndAdvancesPcForNop() throws IllegalInstructionException {
         M68kCpu cpu = new M68kCpu();
@@ -75,19 +78,15 @@ class M68kCpuStepTest {
     void stepFetchesDecodesDispatchesAndUpdatesFlagsForTstDataRegister() throws IllegalInstructionException {
         M68kCpu cpu = new M68kCpu();
         cpu.registers().setProgramCounter(0x0000_1000);
-        cpu.registers().setData(0, 0x0000_0080);
-        cpu.statusRegister().setExtend(true);
-        cpu.statusRegister().setCarry(true);
-        cpu.statusRegister().setOverflow(true);
-        cpu.statusRegister().setZero(true);
+        configureTstScenario(cpu);
         List<String> logs = new ArrayList<>();
 
-        M68kCpu.StepReport report = cpu.step(busWithOpword(0x0000_1000, 0x4A00), new DispatchTable(), logs::add);
+        M68kCpu.StepReport report = cpu.step(busWithOpword(0x0000_1000, TST_B_D0), new DispatchTable(), logs::add);
 
         assertTrue(report.success());
         assertEquals(0x0000_1000, report.before().programCounter());
         assertEquals(0x0000_1002, report.after().programCounter());
-        assertEquals(0x0000_0080, cpu.registers().data(0));
+        assertEquals(TST_NEGATIVE_BYTE, cpu.registers().data(0));
         assertTrue(cpu.statusRegister().isNegativeSet());
         assertFalse(cpu.statusRegister().isZeroSet());
         assertFalse(cpu.statusRegister().isOverflowSet());
@@ -97,6 +96,56 @@ class M68kCpuStepTest {
         assertEquals(1, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
         assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
+    }
+
+    @Test
+    void traceTstDataRegisterPipelineToConsole() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureTstScenario(cpu);
+        AddressSpace bus = busWithOpword(0x0000_1000, TST_B_D0);
+        DispatchTable dispatchTable = new DispatchTable();
+
+        System.out.printf("[tst-trace] setup pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue());
+
+        int fetchedOpword = bus.readWord(cpu.registers().programCounter());
+        System.out.printf("[tst-trace] fetch opword=0x%04X pc=0x%08X%n",
+            fetchedOpword, cpu.registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            fetchedOpword,
+            bus,
+            cpu.registers().programCounter() + 2
+        );
+        System.out.printf("[tst-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        Op handler = dispatchTable.lookup(decoded.opcode());
+        System.out.printf("[tst-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
+
+        M68kCpu.StepReport report = cpu.step(
+            bus,
+            dispatchTable,
+            message -> System.out.println("[tst-trace] execute " + message)
+        );
+
+        System.out.printf("[tst-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue(),
+            cpu.statusRegister().isExtendSet(),
+            cpu.statusRegister().isNegativeSet(),
+            cpu.statusRegister().isZeroSet(),
+            cpu.statusRegister().isOverflowSet(),
+            cpu.statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
     }
 
     @Test
@@ -154,5 +203,13 @@ class M68kCpuStepTest {
         bus.addRegion(ram);
         bus.writeWord(baseAddress, opword);
         return bus;
+    }
+
+    private static void configureTstScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, TST_NEGATIVE_BYTE);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setZero(true);
     }
 }

--- a/src/test/java/com/JMPE/integration/SmallProgramTest.java
+++ b/src/test/java/com/JMPE/integration/SmallProgramTest.java
@@ -112,9 +112,6 @@ class SmallProgramTest {
         System.out.printf("[machine-tst-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
             decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
 
-        Op handler = new DispatchTable().lookup(decoded.opcode());
-        System.out.printf("[machine-tst-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
-
         M68kCpu.StepReport report = machine.step(
             message -> System.out.println("[machine-tst-trace] execute " + message)
         );

--- a/src/test/java/com/JMPE/integration/SmallProgramTest.java
+++ b/src/test/java/com/JMPE/integration/SmallProgramTest.java
@@ -4,8 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.JMPE.cpu.m68k.Decoder;
 import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.dispatch.DispatchTable;
+import com.JMPE.cpu.m68k.dispatch.Op;
 import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
 import com.JMPE.machine.MacPlusMachine;
 import org.junit.jupiter.api.Test;
 
@@ -65,11 +69,7 @@ class SmallProgramTest {
     @Test
     void stepsTstDataRegisterThroughMachineLayer() throws IllegalInstructionException {
         MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(TST_B_D0), ROM_BASE);
-        machine.cpu().registers().setData(0, 0x0000_0080);
-        machine.cpu().statusRegister().setExtend(true);
-        machine.cpu().statusRegister().setCarry(true);
-        machine.cpu().statusRegister().setOverflow(true);
-        machine.cpu().statusRegister().setZero(true);
+        configureTstScenario(machine.cpu());
         List<String> logs = new ArrayList<>();
 
         M68kCpu.StepReport report = machine.step(logs::add);
@@ -88,6 +88,54 @@ class SmallProgramTest {
         assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
     }
 
+    @Test
+    void traceTstDataRegisterThroughMachineLayerToConsole() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(TST_B_D0), ROM_BASE);
+        configureTstScenario(machine.cpu());
+
+        System.out.printf("[machine-tst-trace] machine romBase=0x%08X bus=%s%n",
+            machine.rom().baseAddress(), machine.bus().getClass().getSimpleName());
+        System.out.printf("[machine-tst-trace] reset ssp=0x%08X pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            machine.cpu().registers().stackPointer(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue());
+        System.out.printf("[machine-tst-trace] fetch opword=0x%04X pc=0x%08X%n",
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.cpu().registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.bus(),
+            machine.cpu().registers().programCounter() + 2
+        );
+        System.out.printf("[machine-tst-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        Op handler = new DispatchTable().lookup(decoded.opcode());
+        System.out.printf("[machine-tst-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
+
+        M68kCpu.StepReport report = machine.step(
+            message -> System.out.println("[machine-tst-trace] execute " + message)
+        );
+
+        System.out.printf("[machine-tst-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue(),
+            machine.cpu().statusRegister().isExtendSet(),
+            machine.cpu().statusRegister().isNegativeSet(),
+            machine.cpu().statusRegister().isZeroSet(),
+            machine.cpu().statusRegister().isOverflowSet(),
+            machine.cpu().statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER + 2, machine.cpu().registers().programCounter());
+        assertEquals(4, report.cycles());
+    }
+
     private static byte[] romBytesWithSingleInstruction(int opword) {
         byte[] bytes = new byte[0x0200];
 
@@ -104,5 +152,13 @@ class SmallProgramTest {
         bytes[INSTRUCTION_OFFSET] = (byte) ((opword >>> 8) & 0xFF);
         bytes[INSTRUCTION_OFFSET + 1] = (byte) (opword & 0xFF);
         return bytes;
+    }
+
+    private static void configureTstScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, 0x0000_0080);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setZero(true);
     }
 }

--- a/tools/machine-tst-trace.sh
+++ b/tools/machine-tst-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.integration.SmallProgramTest.traceTstDataRegisterThroughMachineLayerToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[machine-tst-trace\]|\[m68k-step\]"

--- a/tools/tst-trace.sh
+++ b/tools/tst-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.cpu.m68k.M68kCpuStepTest.traceTstDataRegisterPipelineToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[tst-trace\]|\[m68k-step\]"


### PR DESCRIPTION
Add CPU-layer and machine-layer TST trace tests plus helper scripts so the supported TST.B D0 path can be traced like the existing NOP commands.