### PR TITLE
Complete five-instruction dispatch pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ To see the current end-to-end trace flows with only the important lines:
 # Machine-layer NOP trace
 ./tools/machine-nop-trace.sh
 
+# CPU-layer CLR.B D0 trace
+./tools/clr-trace.sh
+
+# Machine-layer CLR.B D0 trace
+./tools/machine-clr-trace.sh
+
+# CPU-layer NOT.B D0 trace
+./tools/not-trace.sh
+
+# Machine-layer NOT.B D0 trace
+./tools/machine-not-trace.sh
+
+# CPU-layer ORI.B #$80,D0 trace
+./tools/ori-trace.sh
+
+# Machine-layer ORI.B #$80,D0 trace
+./tools/machine-ori-trace.sh
+
 # CPU-layer TST.B D0 trace
 ./tools/tst-trace.sh
 

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/ClrOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/ClrOp.java
@@ -10,13 +10,20 @@ import com.JMPE.cpu.m68k.instructions.data.Clr;
 import java.util.Objects;
 
 /**
- * Dispatch-layer executor shell for decoded {@code CLR} instructions.
+ * Dispatch-layer executor for decoded {@code CLR} instructions.
  *
  * <p>
- * This class is intentionally being wired in incremental steps. At this stage,
- * it only establishes the runtime adapter shape used by {@link DispatchTable}:
- * an {@link Op} implementation that receives the live CPU plus the decoded
- * instruction.
+ * This implementation validates that the decoded instruction is a proper
+ * {@link Opcode#CLR} with a sized operand, no source, a destination operand,
+ * and no extension payload, and then executes the operation.
+ * </p>
+ *
+ * <p>
+ * Runtime execution is currently limited to a data-register-direct destination
+ * ({@link EffectiveAddress.DataReg}). Other addressing modes should be
+ * rejected by the validation logic above until explicit support is added.
+ * As additional CLR addressing modes are wired into the dispatch layer, this
+ * Javadoc should be kept in sync with the supported behavior and limitations.
  * </p>
  */
 public final class ClrOp implements Op {

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/ClrOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/ClrOp.java
@@ -1,0 +1,71 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.data.Clr;
+
+import java.util.Objects;
+
+/**
+ * Dispatch-layer executor shell for decoded {@code CLR} instructions.
+ *
+ * <p>
+ * This class is intentionally being wired in incremental steps. At this stage,
+ * it only establishes the runtime adapter shape used by {@link DispatchTable}:
+ * an {@link Op} implementation that receives the live CPU plus the decoded
+ * instruction.
+ * </p>
+ */
+public final class ClrOp implements Op {
+    @Override
+    public int execute(M68kCpu cpu, DecodedInstruction decoded) {
+        Objects.requireNonNull(cpu, "cpu must not be null");
+        Objects.requireNonNull(decoded, "decoded must not be null");
+
+        EffectiveAddress.DataReg destination = validate(decoded);
+        return Clr.execute(
+                decoded.size(),
+                value -> writeDataRegister(cpu, destination.reg(), decoded.size(), value),
+                cpu.statusRegister().moveConditionCodes()
+        );
+    }
+
+    private static EffectiveAddress.DataReg validate(DecodedInstruction decoded) {
+        if (decoded.opcode() != Opcode.CLR) {
+            throw new IllegalArgumentException("ClrOp requires opcode CLR but was " + decoded.opcode());
+        }
+        if (!decoded.size().isSized()) {
+            throw new IllegalArgumentException("CLR must be decoded with a sized operand");
+        }
+        if (!decoded.hasNoSource()) {
+            throw new IllegalArgumentException("CLR must not have a source operand");
+        }
+        if (decoded.hasNoDestination()) {
+            throw new IllegalArgumentException("CLR must have a destination operand");
+        }
+        if (decoded.extension() != 0) {
+            throw new IllegalArgumentException("CLR must not carry an extension payload");
+        }
+        if (!(decoded.dst() instanceof EffectiveAddress.DataReg dataRegister)) {
+            throw new IllegalArgumentException(
+                    "CLR runtime currently supports data-register-direct destination only but was " + decoded.dst()
+            );
+        }
+        return dataRegister;
+    }
+
+    private static void writeDataRegister(M68kCpu cpu, int register, Size size, int value) {
+        int currentValue = cpu.registers().data(register);
+        int maskedValue = size.mask(value);
+        int nextValue = switch (size) {
+            case BYTE -> (currentValue & 0xFFFF_FF00) | maskedValue;
+            case WORD -> (currentValue & 0xFFFF_0000) | maskedValue;
+            case LONG -> maskedValue;
+            case UNSIZED -> throw new IllegalArgumentException("CLR data-register writes require a sized operation");
+        };
+        cpu.registers().setData(register, nextValue);
+    }
+}

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchTable.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchTable.java
@@ -90,7 +90,10 @@ public final class DispatchTable {
     }
 
     private void registerBuiltIns() {
+        register(Opcode.CLR, new ClrOp());
         register(Opcode.NOP, new NopOp());
+        register(Opcode.NOT, new NotOp());
+        register(Opcode.ORI, new OriOp());
         register(Opcode.TST, new TstOp());
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/NotOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/NotOp.java
@@ -1,0 +1,78 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.logic.Not;
+
+import java.util.Objects;
+
+/**
+ * Dispatch-layer executor for decoded {@code NOT} instructions.
+ *
+ * <p>
+ * The raw {@link Not} helper only knows how to complement a sized destination
+ * operand and update CCR flags. {@code NotOp} is the runtime bridge that
+ * validates the decoded shape and resolves the currently supported
+ * data-register-direct destination from live CPU state.
+ * </p>
+ *
+ * <p>
+ * Like the current {@link ClrOp} and {@link TstOp} runtime milestones, this
+ * adapter intentionally supports only data-register-direct destinations until a
+ * shared bus-backed effective-address read/write layer exists.
+ * </p>
+ */
+public final class NotOp implements Op {
+    @Override
+    public int execute(M68kCpu cpu, DecodedInstruction decoded) {
+        Objects.requireNonNull(cpu, "cpu must not be null");
+        Objects.requireNonNull(decoded, "decoded must not be null");
+
+        EffectiveAddress.DataReg destination = validate(decoded);
+        return Not.execute(
+                decoded.size(),
+                () -> cpu.registers().data(destination.reg()),
+                value -> writeDataRegister(cpu, destination.reg(), decoded.size(), value),
+                cpu.statusRegister().moveConditionCodes()
+        );
+    }
+
+    private static EffectiveAddress.DataReg validate(DecodedInstruction decoded) {
+        if (decoded.opcode() != Opcode.NOT) {
+            throw new IllegalArgumentException("NotOp requires opcode NOT but was " + decoded.opcode());
+        }
+        if (!decoded.size().isSized()) {
+            throw new IllegalArgumentException("NOT must be decoded with a sized operand");
+        }
+        if (!decoded.hasNoSource()) {
+            throw new IllegalArgumentException("NOT must not have a source operand");
+        }
+        if (decoded.hasNoDestination()) {
+            throw new IllegalArgumentException("NOT must have a destination operand");
+        }
+        if (decoded.extension() != 0) {
+            throw new IllegalArgumentException("NOT must not carry an extension payload");
+        }
+        if (!(decoded.dst() instanceof EffectiveAddress.DataReg dataRegister)) {
+            throw new IllegalArgumentException(
+                    "NOT runtime currently supports data-register-direct destination only but was " + decoded.dst()
+            );
+        }
+        return dataRegister;
+    }
+
+    private static void writeDataRegister(M68kCpu cpu, int register, Size size, int value) {
+        int currentValue = cpu.registers().data(register);
+        int maskedValue = size.mask(value);
+        int nextValue = switch (size) {
+            case BYTE -> (currentValue & 0xFFFF_FF00) | maskedValue;
+            case WORD -> (currentValue & 0xFFFF_0000) | maskedValue;
+            case LONG -> maskedValue;
+            case UNSIZED -> throw new IllegalArgumentException("NOT data-register writes require a sized operation");
+        };
+        cpu.registers().setData(register, nextValue);
+    }
+}

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/Op.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/Op.java
@@ -1,5 +1,6 @@
 package com.JMPE.cpu.m68k.dispatch;
 
+import com.JMPE.cpu.m68k.EffectiveAddress;
 import com.JMPE.cpu.m68k.M68kCpu;
 import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
 

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/OriOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/OriOp.java
@@ -1,0 +1,87 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.logic.Or;
+
+import java.util.Objects;
+
+/**
+ * Dispatch-layer executor for decoded {@code ORI} instructions.
+ *
+ * <p>
+ * The raw {@link Or} helper only knows how to bitwise-OR a sized source and
+ * destination operand, write the result, and update CCR flags. {@code OriOp} is
+ * the runtime bridge that validates the decoded shape and resolves the
+ * currently supported immediate-source/data-register-destination form from live
+ * CPU state.
+ * </p>
+ *
+ * <p>
+ * Like the other current runtime-backed instruction adapters, this first
+ * milestone intentionally supports only the data-register-direct destination
+ * form. Broader effective-address support can follow once a shared bus-backed
+ * operand access layer exists in the dispatch path.
+ * </p>
+ */
+public final class OriOp implements Op {
+    @Override
+    public int execute(M68kCpu cpu, DecodedInstruction decoded) {
+        Objects.requireNonNull(cpu, "cpu must not be null");
+        Objects.requireNonNull(decoded, "decoded must not be null");
+
+        Operands operands = validate(decoded);
+        return Or.execute(
+                decoded.size(),
+                operands.source()::value,
+                () -> cpu.registers().data(operands.destination().reg()),
+                value -> writeDataRegister(cpu, operands.destination().reg(), decoded.size(), value),
+                cpu.statusRegister().moveConditionCodes()
+        );
+    }
+
+    private static Operands validate(DecodedInstruction decoded) {
+        if (decoded.opcode() != Opcode.ORI) {
+            throw new IllegalArgumentException("OriOp requires opcode ORI but was " + decoded.opcode());
+        }
+        if (!decoded.size().isSized()) {
+            throw new IllegalArgumentException("ORI must be decoded with a sized operand");
+        }
+        if (!(decoded.src() instanceof EffectiveAddress.Immediate immediate)) {
+            throw new IllegalArgumentException(
+                    "ORI runtime currently supports immediate source only but was " + decoded.src()
+            );
+        }
+        if (decoded.hasNoDestination()) {
+            throw new IllegalArgumentException("ORI must have a destination operand");
+        }
+        if (decoded.extension() != 0) {
+            throw new IllegalArgumentException("ORI must not carry an extension payload");
+        }
+        if (!(decoded.dst() instanceof EffectiveAddress.DataReg dataRegister)) {
+            throw new IllegalArgumentException(
+                    "ORI runtime currently supports data-register-direct destination only but was " + decoded.dst()
+            );
+        }
+        return new Operands(immediate, dataRegister);
+    }
+
+    private static void writeDataRegister(M68kCpu cpu, int register, Size size, int value) {
+        int currentValue = cpu.registers().data(register);
+        int maskedValue = size.mask(value);
+        int nextValue = switch (size) {
+            case BYTE -> (currentValue & 0xFFFF_FF00) | maskedValue;
+            case WORD -> (currentValue & 0xFFFF_0000) | maskedValue;
+            case LONG -> maskedValue;
+            case UNSIZED -> throw new IllegalArgumentException("ORI data-register writes require a sized operation");
+        };
+        cpu.registers().setData(register, nextValue);
+    }
+
+    private record Operands(EffectiveAddress.Immediate source,
+                            EffectiveAddress.DataReg destination) {
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -17,6 +17,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 class M68kCpuStepTest {
+    private static final int CLR_B_D0 = 0x4200;
+    private static final int CLR_BYTE_INITIAL = 0x1234_5678;
+    private static final int CLR_BYTE_RESULT = 0x1234_5600;
+    private static final int NOT_B_D0 = 0x4600;
+    private static final int NOT_BYTE_INITIAL = 0x1234_5600;
+    private static final int NOT_BYTE_RESULT = 0x1234_56FF;
+    private static final int ORI_B_D0 = 0x0000;
+    private static final int ORI_BYTE_IMMEDIATE = 0x0080;
+    private static final int ORI_BYTE_INITIAL = 0x1234_5600;
+    private static final int ORI_BYTE_RESULT = 0x1234_5680;
     private static final int TST_B_D0 = 0x4A00;
     private static final int TST_NEGATIVE_BYTE = 0x0000_0080;
 
@@ -72,6 +82,239 @@ class M68kCpuStepTest {
 
         assertTrue(report.success());
         assertEquals(0x0000_1002, cpu.registers().programCounter());
+    }
+
+    @Test
+    void stepFetchesDecodesDispatchesWritesDataRegisterAndUpdatesFlagsForClrDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureClrScenario(cpu);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = cpu.step(busWithOpword(0x0000_1000, CLR_B_D0), new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1000, report.before().programCounter());
+        assertEquals(CLR_BYTE_INITIAL, report.before().dataRegister(0));
+        assertEquals(0x0000_1002, report.after().programCounter());
+        assertEquals(CLR_BYTE_RESULT, report.after().dataRegister(0));
+        assertEquals(CLR_BYTE_RESULT, cpu.registers().data(0));
+        assertFalse(cpu.statusRegister().isNegativeSet());
+        assertTrue(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=CLR"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
+    }
+
+    @Test
+    void traceClrDataRegisterPipelineToConsole() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureClrScenario(cpu);
+        AddressSpace bus = busWithOpword(0x0000_1000, CLR_B_D0);
+        DispatchTable dispatchTable = new DispatchTable();
+
+        System.out.printf("[clr-trace] setup pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue());
+
+        int fetchedOpword = bus.readWord(cpu.registers().programCounter());
+        System.out.printf("[clr-trace] fetch opword=0x%04X pc=0x%08X%n",
+            fetchedOpword, cpu.registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            fetchedOpword,
+            bus,
+            cpu.registers().programCounter() + 2
+        );
+        System.out.printf("[clr-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        Op handler = dispatchTable.lookup(decoded.opcode());
+        System.out.printf("[clr-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
+
+        M68kCpu.StepReport report = cpu.step(
+            bus,
+            dispatchTable,
+            message -> System.out.println("[clr-trace] execute " + message)
+        );
+
+        System.out.printf("[clr-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue(),
+            cpu.statusRegister().isExtendSet(),
+            cpu.statusRegister().isNegativeSet(),
+            cpu.statusRegister().isZeroSet(),
+            cpu.statusRegister().isOverflowSet(),
+            cpu.statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
+    }
+
+    @Test
+    void stepFetchesDecodesDispatchesWritesDataRegisterAndUpdatesFlagsForNotDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureNotScenario(cpu);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = cpu.step(busWithOpword(0x0000_1000, NOT_B_D0), new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1000, report.before().programCounter());
+        assertEquals(NOT_BYTE_INITIAL, report.before().dataRegister(0));
+        assertEquals(0x0000_1002, report.after().programCounter());
+        assertEquals(NOT_BYTE_RESULT, report.after().dataRegister(0));
+        assertEquals(NOT_BYTE_RESULT, cpu.registers().data(0));
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=NOT"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
+    }
+
+    @Test
+    void traceNotDataRegisterPipelineToConsole() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureNotScenario(cpu);
+        AddressSpace bus = busWithOpword(0x0000_1000, NOT_B_D0);
+        DispatchTable dispatchTable = new DispatchTable();
+
+        System.out.printf("[not-trace] setup pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue());
+
+        int fetchedOpword = bus.readWord(cpu.registers().programCounter());
+        System.out.printf("[not-trace] fetch opword=0x%04X pc=0x%08X%n",
+            fetchedOpword, cpu.registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            fetchedOpword,
+            bus,
+            cpu.registers().programCounter() + 2
+        );
+        System.out.printf("[not-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        Op handler = dispatchTable.lookup(decoded.opcode());
+        System.out.printf("[not-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
+
+        M68kCpu.StepReport report = cpu.step(
+            bus,
+            dispatchTable,
+            message -> System.out.println("[not-trace] execute " + message)
+        );
+
+        System.out.printf("[not-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue(),
+            cpu.statusRegister().isExtendSet(),
+            cpu.statusRegister().isNegativeSet(),
+            cpu.statusRegister().isZeroSet(),
+            cpu.statusRegister().isOverflowSet(),
+            cpu.statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
+    }
+
+    @Test
+    void stepFetchesDecodesDispatchesWritesDataRegisterAndUpdatesFlagsForOriImmediateToDataRegister()
+            throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureOriScenario(cpu);
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = cpu.step(
+                busWithWords(0x0000_1000, ORI_B_D0, ORI_BYTE_IMMEDIATE),
+                new DispatchTable(),
+                logs::add
+        );
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1000, report.before().programCounter());
+        assertEquals(ORI_BYTE_INITIAL, report.before().dataRegister(0));
+        assertEquals(0x0000_1004, report.after().programCounter());
+        assertEquals(ORI_BYTE_RESULT, report.after().dataRegister(0));
+        assertEquals(ORI_BYTE_RESULT, cpu.registers().data(0));
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=ORI"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001004"));
+    }
+
+    @Test
+    void traceOriImmediateToDataRegisterPipelineToConsole() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureOriScenario(cpu);
+        AddressSpace bus = busWithWords(0x0000_1000, ORI_B_D0, ORI_BYTE_IMMEDIATE);
+        DispatchTable dispatchTable = new DispatchTable();
+
+        System.out.printf("[ori-trace] setup pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue());
+
+        int fetchedOpword = bus.readWord(cpu.registers().programCounter());
+        System.out.printf("[ori-trace] fetch opword=0x%04X pc=0x%08X%n",
+            fetchedOpword, cpu.registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            fetchedOpword,
+            bus,
+            cpu.registers().programCounter() + 2
+        );
+        System.out.printf("[ori-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        Op handler = dispatchTable.lookup(decoded.opcode());
+        System.out.printf("[ori-trace] dispatch handler=%s%n", handler.getClass().getSimpleName());
+
+        M68kCpu.StepReport report = cpu.step(
+            bus,
+            dispatchTable,
+            message -> System.out.println("[ori-trace] execute " + message)
+        );
+
+        System.out.printf("[ori-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            cpu.registers().programCounter(),
+            cpu.registers().data(0),
+            cpu.statusRegister().rawValue(),
+            cpu.statusRegister().isExtendSet(),
+            cpu.statusRegister().isNegativeSet(),
+            cpu.statusRegister().isZeroSet(),
+            cpu.statusRegister().isOverflowSet(),
+            cpu.statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(0x0000_1004, cpu.registers().programCounter());
     }
 
     @Test
@@ -198,10 +441,16 @@ class M68kCpuStepTest {
     }
 
     private static AddressSpace busWithOpword(int baseAddress, int opword) {
+        return busWithWords(baseAddress, opword);
+    }
+
+    private static AddressSpace busWithWords(int baseAddress, int... words) {
         Ram ram = new Ram(baseAddress, 64);
         AddressSpace bus = new AddressSpace();
         bus.addRegion(ram);
-        bus.writeWord(baseAddress, opword);
+        for (int index = 0; index < words.length; index++) {
+            bus.writeWord(baseAddress + (index * 2), words[index]);
+        }
         return bus;
     }
 
@@ -210,6 +459,33 @@ class M68kCpuStepTest {
         cpu.statusRegister().setExtend(true);
         cpu.statusRegister().setCarry(true);
         cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setZero(true);
+    }
+
+    private static void configureClrScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, CLR_BYTE_INITIAL);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(true);
+        cpu.statusRegister().setZero(false);
+    }
+
+    private static void configureNotScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, NOT_BYTE_INITIAL);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(false);
+        cpu.statusRegister().setZero(true);
+    }
+
+    private static void configureOriScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, ORI_BYTE_INITIAL);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(false);
         cpu.statusRegister().setZero(true);
     }
 }

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/ClrOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/ClrOpTest.java
@@ -1,0 +1,152 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.data.Clr;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClrOpTest {
+    @Test
+    void executesClrByteOnDataRegisterAndPreservesUpperBits() {
+        M68kCpu cpu = new M68kCpu();
+        configureClrScenario(cpu, 0x1234_5678);
+
+        int cycles = new ClrOp().execute(cpu, decodedClr(Size.BYTE, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Clr.EXECUTION_CYCLES, cycles);
+        assertEquals(0x1234_5600, cpu.registers().data(0));
+        assertClrFlags(cpu);
+    }
+
+    @Test
+    void executesClrWordOnDataRegisterAndPreservesUpperBits() {
+        M68kCpu cpu = new M68kCpu();
+        configureClrScenario(cpu, 0x1234_5678);
+
+        int cycles = new ClrOp().execute(cpu, decodedClr(Size.WORD, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Clr.EXECUTION_CYCLES, cycles);
+        assertEquals(0x1234_0000, cpu.registers().data(0));
+        assertClrFlags(cpu);
+    }
+
+    @Test
+    void executesClrLongOnDataRegisterAndClearsTheWholeRegister() {
+        M68kCpu cpu = new M68kCpu();
+        configureClrScenario(cpu, 0x1234_5678);
+
+        int cycles = new ClrOp().execute(cpu, decodedClr(Size.LONG, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Clr.EXECUTION_CYCLES, cycles);
+        assertEquals(0x0000_0000, cpu.registers().data(0));
+        assertClrFlags(cpu);
+    }
+
+    @Test
+    void rejectsWrongOpcodeOrUnsizedDecode() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction wrongOpcode = new DecodedInstruction(
+                Opcode.NOP,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction unsized = new DecodedInstruction(
+                Opcode.CLR,
+                Size.UNSIZED,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new ClrOp().execute(cpu, wrongOpcode));
+        assertThrows(IllegalArgumentException.class, () -> new ClrOp().execute(cpu, unsized));
+    }
+
+    @Test
+    void rejectsUnsupportedOperandsOrExtensionPayload() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction withSource = new DecodedInstruction(
+                Opcode.CLR,
+                Size.BYTE,
+                EffectiveAddress.immediate(1),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withNoDestination = new DecodedInstruction(
+                Opcode.CLR,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.none(),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withMemoryDestination = new DecodedInstruction(
+                Opcode.CLR,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.addrRegInd(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withExtension = new DecodedInstruction(
+                Opcode.CLR,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                1,
+                0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new ClrOp().execute(cpu, withSource));
+        assertThrows(IllegalArgumentException.class, () -> new ClrOp().execute(cpu, withNoDestination));
+        assertThrows(IllegalArgumentException.class, () -> new ClrOp().execute(cpu, withMemoryDestination));
+        assertThrows(IllegalArgumentException.class, () -> new ClrOp().execute(cpu, withExtension));
+    }
+
+    @Test
+    void rejectsNullInputs() {
+        assertThrows(NullPointerException.class, () -> new ClrOp().execute(null, decodedClr(Size.BYTE, EffectiveAddress.dataReg(0))));
+        assertThrows(NullPointerException.class, () -> new ClrOp().execute(new M68kCpu(), null));
+    }
+
+    private static void assertClrFlags(M68kCpu cpu) {
+        assertFalse(cpu.statusRegister().isNegativeSet());
+        assertTrue(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    private static void configureClrScenario(M68kCpu cpu, int initialValue) {
+        cpu.registers().setData(0, initialValue);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(true);
+        cpu.statusRegister().setZero(false);
+    }
+
+    private static DecodedInstruction decodedClr(Size size, EffectiveAddress destination) {
+        return new DecodedInstruction(
+                Opcode.CLR,
+                size,
+                EffectiveAddress.none(),
+                destination,
+                0,
+                0x0040_0102
+        );
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/DispatchTableTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/DispatchTableTest.java
@@ -10,11 +10,35 @@ import org.junit.jupiter.api.Test;
 
 class DispatchTableTest {
     @Test
+    void providesBuiltInClrHandler() {
+        DispatchTable dispatchTable = new DispatchTable();
+
+        assertTrue(dispatchTable.hasHandler(Opcode.CLR));
+        assertTrue(dispatchTable.lookup(Opcode.CLR) instanceof ClrOp);
+    }
+
+    @Test
     void providesBuiltInNopHandler() {
         DispatchTable dispatchTable = new DispatchTable();
 
         assertTrue(dispatchTable.hasHandler(Opcode.NOP));
         assertTrue(dispatchTable.lookup(Opcode.NOP) instanceof NopOp);
+    }
+
+    @Test
+    void providesBuiltInNotHandler() {
+        DispatchTable dispatchTable = new DispatchTable();
+
+        assertTrue(dispatchTable.hasHandler(Opcode.NOT));
+        assertTrue(dispatchTable.lookup(Opcode.NOT) instanceof NotOp);
+    }
+
+    @Test
+    void providesBuiltInOriHandler() {
+        DispatchTable dispatchTable = new DispatchTable();
+
+        assertTrue(dispatchTable.hasHandler(Opcode.ORI));
+        assertTrue(dispatchTable.lookup(Opcode.ORI) instanceof OriOp);
     }
 
     @Test

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/NotOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/NotOpTest.java
@@ -1,0 +1,152 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.logic.Not;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NotOpTest {
+    @Test
+    void executesNotByteOnDataRegisterAndPreservesUpperBits() {
+        M68kCpu cpu = new M68kCpu();
+        configureNotScenario(cpu, 0x1234_5678);
+
+        int cycles = new NotOp().execute(cpu, decodedNot(Size.BYTE, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Not.EXECUTION_CYCLES, cycles);
+        assertEquals(0x1234_5687, cpu.registers().data(0));
+        assertNotFlags(cpu);
+    }
+
+    @Test
+    void executesNotWordOnDataRegisterAndPreservesUpperBits() {
+        M68kCpu cpu = new M68kCpu();
+        configureNotScenario(cpu, 0x1234_5678);
+
+        int cycles = new NotOp().execute(cpu, decodedNot(Size.WORD, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Not.EXECUTION_CYCLES, cycles);
+        assertEquals(0x1234_A987, cpu.registers().data(0));
+        assertNotFlags(cpu);
+    }
+
+    @Test
+    void executesNotLongOnDataRegisterAndUpdatesTheWholeRegister() {
+        M68kCpu cpu = new M68kCpu();
+        configureNotScenario(cpu, 0x1234_5678);
+
+        int cycles = new NotOp().execute(cpu, decodedNot(Size.LONG, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Not.EXECUTION_CYCLES, cycles);
+        assertEquals(0xEDCB_A987, cpu.registers().data(0));
+        assertNotFlags(cpu);
+    }
+
+    @Test
+    void rejectsWrongOpcodeOrUnsizedDecode() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction wrongOpcode = new DecodedInstruction(
+                Opcode.NOP,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction unsized = new DecodedInstruction(
+                Opcode.NOT,
+                Size.UNSIZED,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new NotOp().execute(cpu, wrongOpcode));
+        assertThrows(IllegalArgumentException.class, () -> new NotOp().execute(cpu, unsized));
+    }
+
+    @Test
+    void rejectsUnsupportedOperandsOrExtensionPayload() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction withSource = new DecodedInstruction(
+                Opcode.NOT,
+                Size.BYTE,
+                EffectiveAddress.immediate(1),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withNoDestination = new DecodedInstruction(
+                Opcode.NOT,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.none(),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withMemoryDestination = new DecodedInstruction(
+                Opcode.NOT,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.addrRegInd(0),
+                0,
+                0x0040_0102
+        );
+        DecodedInstruction withExtension = new DecodedInstruction(
+                Opcode.NOT,
+                Size.BYTE,
+                EffectiveAddress.none(),
+                EffectiveAddress.dataReg(0),
+                1,
+                0x0040_0102
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new NotOp().execute(cpu, withSource));
+        assertThrows(IllegalArgumentException.class, () -> new NotOp().execute(cpu, withNoDestination));
+        assertThrows(IllegalArgumentException.class, () -> new NotOp().execute(cpu, withMemoryDestination));
+        assertThrows(IllegalArgumentException.class, () -> new NotOp().execute(cpu, withExtension));
+    }
+
+    @Test
+    void rejectsNullInputs() {
+        assertThrows(NullPointerException.class, () -> new NotOp().execute(null, decodedNot(Size.BYTE, EffectiveAddress.dataReg(0))));
+        assertThrows(NullPointerException.class, () -> new NotOp().execute(new M68kCpu(), null));
+    }
+
+    private static void assertNotFlags(M68kCpu cpu) {
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    private static void configureNotScenario(M68kCpu cpu, int initialValue) {
+        cpu.registers().setData(0, initialValue);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(false);
+        cpu.statusRegister().setZero(true);
+    }
+
+    private static DecodedInstruction decodedNot(Size size, EffectiveAddress destination) {
+        return new DecodedInstruction(
+                Opcode.NOT,
+                size,
+                EffectiveAddress.none(),
+                destination,
+                0,
+                0x0040_0102
+        );
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/OriOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/OriOpTest.java
@@ -1,0 +1,152 @@
+package com.JMPE.cpu.m68k.dispatch;
+
+import com.JMPE.cpu.m68k.EffectiveAddress;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.logic.Or;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OriOpTest {
+    @Test
+    void executesOriByteImmediateOnDataRegisterAndPreservesUpperBits() {
+        M68kCpu cpu = new M68kCpu();
+        configureOriScenario(cpu, 0x1234_5600);
+
+        int cycles = new OriOp().execute(cpu, decodedOri(Size.BYTE, 0x80, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Or.EXECUTION_CYCLES, cycles);
+        assertEquals(0x1234_5680, cpu.registers().data(0));
+        assertOriNegativeFlags(cpu);
+    }
+
+    @Test
+    void executesOriWordImmediateOnDataRegisterAndPreservesUpperBits() {
+        M68kCpu cpu = new M68kCpu();
+        configureOriScenario(cpu, 0x1234_0000);
+
+        int cycles = new OriOp().execute(cpu, decodedOri(Size.WORD, 0x8001, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Or.EXECUTION_CYCLES, cycles);
+        assertEquals(0x1234_8001, cpu.registers().data(0));
+        assertOriNegativeFlags(cpu);
+    }
+
+    @Test
+    void executesOriLongImmediateOnDataRegisterAndUpdatesTheWholeRegister() {
+        M68kCpu cpu = new M68kCpu();
+        configureOriScenario(cpu, 0x0234_5678);
+
+        int cycles = new OriOp().execute(cpu, decodedOri(Size.LONG, 0x8000_0000, EffectiveAddress.dataReg(0)));
+
+        assertEquals(Or.EXECUTION_CYCLES, cycles);
+        assertEquals(0x8234_5678, cpu.registers().data(0));
+        assertOriNegativeFlags(cpu);
+    }
+
+    @Test
+    void rejectsWrongOpcodeOrUnsizedDecode() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction wrongOpcode = new DecodedInstruction(
+                Opcode.NOP,
+                Size.BYTE,
+                EffectiveAddress.immediate(0x80),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0104
+        );
+        DecodedInstruction unsized = new DecodedInstruction(
+                Opcode.ORI,
+                Size.UNSIZED,
+                EffectiveAddress.immediate(0x80),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0104
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new OriOp().execute(cpu, wrongOpcode));
+        assertThrows(IllegalArgumentException.class, () -> new OriOp().execute(cpu, unsized));
+    }
+
+    @Test
+    void rejectsUnsupportedOperandsOrExtensionPayload() {
+        M68kCpu cpu = new M68kCpu();
+        DecodedInstruction withRegisterSource = new DecodedInstruction(
+                Opcode.ORI,
+                Size.BYTE,
+                EffectiveAddress.dataReg(1),
+                EffectiveAddress.dataReg(0),
+                0,
+                0x0040_0104
+        );
+        DecodedInstruction withNoDestination = new DecodedInstruction(
+                Opcode.ORI,
+                Size.BYTE,
+                EffectiveAddress.immediate(0x80),
+                EffectiveAddress.none(),
+                0,
+                0x0040_0104
+        );
+        DecodedInstruction withMemoryDestination = new DecodedInstruction(
+                Opcode.ORI,
+                Size.BYTE,
+                EffectiveAddress.immediate(0x80),
+                EffectiveAddress.addrRegInd(0),
+                0,
+                0x0040_0104
+        );
+        DecodedInstruction withExtension = new DecodedInstruction(
+                Opcode.ORI,
+                Size.BYTE,
+                EffectiveAddress.immediate(0x80),
+                EffectiveAddress.dataReg(0),
+                1,
+                0x0040_0104
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> new OriOp().execute(cpu, withRegisterSource));
+        assertThrows(IllegalArgumentException.class, () -> new OriOp().execute(cpu, withNoDestination));
+        assertThrows(IllegalArgumentException.class, () -> new OriOp().execute(cpu, withMemoryDestination));
+        assertThrows(IllegalArgumentException.class, () -> new OriOp().execute(cpu, withExtension));
+    }
+
+    @Test
+    void rejectsNullInputs() {
+        assertThrows(NullPointerException.class, () -> new OriOp().execute(null, decodedOri(Size.BYTE, 0x80, EffectiveAddress.dataReg(0))));
+        assertThrows(NullPointerException.class, () -> new OriOp().execute(new M68kCpu(), null));
+    }
+
+    private static void assertOriNegativeFlags(M68kCpu cpu) {
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isOverflowSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    private static void configureOriScenario(M68kCpu cpu, int initialValue) {
+        cpu.registers().setData(0, initialValue);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(false);
+        cpu.statusRegister().setZero(true);
+    }
+
+    private static DecodedInstruction decodedOri(Size size, int immediate, EffectiveAddress destination) {
+        return new DecodedInstruction(
+                Opcode.ORI,
+                size,
+                EffectiveAddress.immediate(immediate),
+                destination,
+                0,
+                0x0040_0104
+        );
+    }
+}

--- a/src/test/java/com/JMPE/integration/SmallProgramTest.java
+++ b/src/test/java/com/JMPE/integration/SmallProgramTest.java
@@ -22,6 +22,16 @@ class SmallProgramTest {
     private static final int INITIAL_PROGRAM_COUNTER = 0x0040_0100;
     private static final int INSTRUCTION_OFFSET = INITIAL_PROGRAM_COUNTER - ROM_BASE;
     private static final int NOP = 0x4E71;
+    private static final int CLR_B_D0 = 0x4200;
+    private static final int CLR_BYTE_INITIAL = 0x1234_5678;
+    private static final int CLR_BYTE_RESULT = 0x1234_5600;
+    private static final int NOT_B_D0 = 0x4600;
+    private static final int NOT_BYTE_INITIAL = 0x1234_5600;
+    private static final int NOT_BYTE_RESULT = 0x1234_56FF;
+    private static final int ORI_B_D0 = 0x0000;
+    private static final int ORI_BYTE_IMMEDIATE = 0x0080;
+    private static final int ORI_BYTE_INITIAL = 0x1234_5600;
+    private static final int ORI_BYTE_RESULT = 0x1234_5680;
     private static final int TST_B_D0 = 0x4A00;
 
     @Test
@@ -64,6 +74,222 @@ class SmallProgramTest {
         assertTrue(report.success());
         assertEquals(INITIAL_PROGRAM_COUNTER + 2, machine.cpu().registers().programCounter());
         assertEquals(4, report.cycles());
+    }
+
+    @Test
+    void stepsClrDataRegisterThroughMachineLayer() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(CLR_B_D0), ROM_BASE);
+        configureClrScenario(machine.cpu());
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = machine.step(logs::add);
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER, report.before().programCounter());
+        assertEquals(CLR_BYTE_INITIAL, report.before().dataRegister(0));
+        assertEquals(INITIAL_PROGRAM_COUNTER + 2, report.after().programCounter());
+        assertEquals(CLR_BYTE_RESULT, report.after().dataRegister(0));
+        assertEquals(CLR_BYTE_RESULT, machine.cpu().registers().data(0));
+        assertFalse(machine.cpu().statusRegister().isNegativeSet());
+        assertTrue(machine.cpu().statusRegister().isZeroSet());
+        assertFalse(machine.cpu().statusRegister().isOverflowSet());
+        assertFalse(machine.cpu().statusRegister().isCarrySet());
+        assertTrue(machine.cpu().statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=CLR"));
+    }
+
+    @Test
+    void traceClrDataRegisterThroughMachineLayerToConsole() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(CLR_B_D0), ROM_BASE);
+        configureClrScenario(machine.cpu());
+
+        System.out.printf("[machine-clr-trace] machine romBase=0x%08X bus=%s%n",
+            machine.rom().baseAddress(), machine.bus().getClass().getSimpleName());
+        System.out.printf("[machine-clr-trace] reset ssp=0x%08X pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            machine.cpu().registers().stackPointer(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue());
+        System.out.printf("[machine-clr-trace] fetch opword=0x%04X pc=0x%08X%n",
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.cpu().registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.bus(),
+            machine.cpu().registers().programCounter() + 2
+        );
+        System.out.printf("[machine-clr-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        M68kCpu.StepReport report = machine.step(
+            message -> System.out.println("[machine-clr-trace] execute " + message)
+        );
+
+        System.out.printf("[machine-clr-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue(),
+            machine.cpu().statusRegister().isExtendSet(),
+            machine.cpu().statusRegister().isNegativeSet(),
+            machine.cpu().statusRegister().isZeroSet(),
+            machine.cpu().statusRegister().isOverflowSet(),
+            machine.cpu().statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER + 2, machine.cpu().registers().programCounter());
+        assertEquals(4, report.cycles());
+        assertEquals(CLR_BYTE_RESULT, machine.cpu().registers().data(0));
+    }
+
+    @Test
+    void stepsNotDataRegisterThroughMachineLayer() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(NOT_B_D0), ROM_BASE);
+        configureNotScenario(machine.cpu());
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = machine.step(logs::add);
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER, report.before().programCounter());
+        assertEquals(NOT_BYTE_INITIAL, report.before().dataRegister(0));
+        assertEquals(INITIAL_PROGRAM_COUNTER + 2, report.after().programCounter());
+        assertEquals(NOT_BYTE_RESULT, report.after().dataRegister(0));
+        assertEquals(NOT_BYTE_RESULT, machine.cpu().registers().data(0));
+        assertTrue(machine.cpu().statusRegister().isNegativeSet());
+        assertFalse(machine.cpu().statusRegister().isZeroSet());
+        assertFalse(machine.cpu().statusRegister().isOverflowSet());
+        assertFalse(machine.cpu().statusRegister().isCarrySet());
+        assertTrue(machine.cpu().statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=NOT"));
+    }
+
+    @Test
+    void traceNotDataRegisterThroughMachineLayerToConsole() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(romBytesWithSingleInstruction(NOT_B_D0), ROM_BASE);
+        configureNotScenario(machine.cpu());
+
+        System.out.printf("[machine-not-trace] machine romBase=0x%08X bus=%s%n",
+            machine.rom().baseAddress(), machine.bus().getClass().getSimpleName());
+        System.out.printf("[machine-not-trace] reset ssp=0x%08X pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            machine.cpu().registers().stackPointer(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue());
+        System.out.printf("[machine-not-trace] fetch opword=0x%04X pc=0x%08X%n",
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.cpu().registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.bus(),
+            machine.cpu().registers().programCounter() + 2
+        );
+        System.out.printf("[machine-not-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        M68kCpu.StepReport report = machine.step(
+            message -> System.out.println("[machine-not-trace] execute " + message)
+        );
+
+        System.out.printf("[machine-not-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue(),
+            machine.cpu().statusRegister().isExtendSet(),
+            machine.cpu().statusRegister().isNegativeSet(),
+            machine.cpu().statusRegister().isZeroSet(),
+            machine.cpu().statusRegister().isOverflowSet(),
+            machine.cpu().statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER + 2, machine.cpu().registers().programCounter());
+        assertEquals(4, report.cycles());
+        assertEquals(NOT_BYTE_RESULT, machine.cpu().registers().data(0));
+    }
+
+    @Test
+    void stepsOriImmediateToDataRegisterThroughMachineLayer() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(
+                romBytesWithInstructionWords(ORI_B_D0, ORI_BYTE_IMMEDIATE),
+                ROM_BASE
+        );
+        configureOriScenario(machine.cpu());
+        List<String> logs = new ArrayList<>();
+
+        M68kCpu.StepReport report = machine.step(logs::add);
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER, report.before().programCounter());
+        assertEquals(ORI_BYTE_INITIAL, report.before().dataRegister(0));
+        assertEquals(INITIAL_PROGRAM_COUNTER + 4, report.after().programCounter());
+        assertEquals(ORI_BYTE_RESULT, report.after().dataRegister(0));
+        assertEquals(ORI_BYTE_RESULT, machine.cpu().registers().data(0));
+        assertTrue(machine.cpu().statusRegister().isNegativeSet());
+        assertFalse(machine.cpu().statusRegister().isZeroSet());
+        assertFalse(machine.cpu().statusRegister().isOverflowSet());
+        assertFalse(machine.cpu().statusRegister().isCarrySet());
+        assertTrue(machine.cpu().statusRegister().isExtendSet());
+        assertEquals(4, report.cycles());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=ORI"));
+    }
+
+    @Test
+    void traceOriImmediateToDataRegisterThroughMachineLayerToConsole() throws IllegalInstructionException {
+        MacPlusMachine machine = MacPlusMachine.fromRomBytes(
+                romBytesWithInstructionWords(ORI_B_D0, ORI_BYTE_IMMEDIATE),
+                ROM_BASE
+        );
+        configureOriScenario(machine.cpu());
+
+        System.out.printf("[machine-ori-trace] machine romBase=0x%08X bus=%s%n",
+            machine.rom().baseAddress(), machine.bus().getClass().getSimpleName());
+        System.out.printf("[machine-ori-trace] reset ssp=0x%08X pc=0x%08X d0=0x%08X sr=0x%04X%n",
+            machine.cpu().registers().stackPointer(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue());
+        System.out.printf("[machine-ori-trace] fetch opword=0x%04X pc=0x%08X%n",
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.cpu().registers().programCounter());
+
+        DecodedInstruction decoded = new Decoder().decode(
+            machine.bus().readWord(machine.cpu().registers().programCounter()),
+            machine.bus(),
+            machine.cpu().registers().programCounter() + 2
+        );
+        System.out.printf("[machine-ori-trace] decode opcode=%s size=%s src=%s dst=%s nextPc=0x%08X%n",
+            decoded.opcode(), decoded.size(), decoded.src(), decoded.dst(), decoded.nextPc());
+
+        M68kCpu.StepReport report = machine.step(
+            message -> System.out.println("[machine-ori-trace] execute " + message)
+        );
+
+        System.out.printf("[machine-ori-trace] result success=%s cycles=%d finalPc=0x%08X d0=0x%08X sr=0x%04X X=%s N=%s Z=%s V=%s C=%s%n",
+            report.success(),
+            report.cycles(),
+            machine.cpu().registers().programCounter(),
+            machine.cpu().registers().data(0),
+            machine.cpu().statusRegister().rawValue(),
+            machine.cpu().statusRegister().isExtendSet(),
+            machine.cpu().statusRegister().isNegativeSet(),
+            machine.cpu().statusRegister().isZeroSet(),
+            machine.cpu().statusRegister().isOverflowSet(),
+            machine.cpu().statusRegister().isCarrySet());
+
+        assertTrue(report.success());
+        assertEquals(INITIAL_PROGRAM_COUNTER + 4, machine.cpu().registers().programCounter());
+        assertEquals(4, report.cycles());
+        assertEquals(ORI_BYTE_RESULT, machine.cpu().registers().data(0));
     }
 
     @Test
@@ -134,6 +360,10 @@ class SmallProgramTest {
     }
 
     private static byte[] romBytesWithSingleInstruction(int opword) {
+        return romBytesWithInstructionWords(opword);
+    }
+
+    private static byte[] romBytesWithInstructionWords(int... words) {
         byte[] bytes = new byte[0x0200];
 
         bytes[0] = 0x00;
@@ -146,8 +376,12 @@ class SmallProgramTest {
         bytes[6] = 0x01;
         bytes[7] = 0x00;
 
-        bytes[INSTRUCTION_OFFSET] = (byte) ((opword >>> 8) & 0xFF);
-        bytes[INSTRUCTION_OFFSET + 1] = (byte) (opword & 0xFF);
+        for (int index = 0; index < words.length; index++) {
+            int word = words[index];
+            int offset = INSTRUCTION_OFFSET + (index * 2);
+            bytes[offset] = (byte) ((word >>> 8) & 0xFF);
+            bytes[offset + 1] = (byte) (word & 0xFF);
+        }
         return bytes;
     }
 
@@ -156,6 +390,33 @@ class SmallProgramTest {
         cpu.statusRegister().setExtend(true);
         cpu.statusRegister().setCarry(true);
         cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setZero(true);
+    }
+
+    private static void configureClrScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, CLR_BYTE_INITIAL);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(true);
+        cpu.statusRegister().setZero(false);
+    }
+
+    private static void configureNotScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, NOT_BYTE_INITIAL);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(false);
+        cpu.statusRegister().setZero(true);
+    }
+
+    private static void configureOriScenario(M68kCpu cpu) {
+        cpu.registers().setData(0, ORI_BYTE_INITIAL);
+        cpu.statusRegister().setExtend(true);
+        cpu.statusRegister().setCarry(true);
+        cpu.statusRegister().setOverflow(true);
+        cpu.statusRegister().setNegative(false);
         cpu.statusRegister().setZero(true);
     }
 }

--- a/tools/clr-trace.sh
+++ b/tools/clr-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.cpu.m68k.M68kCpuStepTest.traceClrDataRegisterPipelineToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[clr-trace\]|\[m68k-step\]"

--- a/tools/machine-clr-trace.sh
+++ b/tools/machine-clr-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.integration.SmallProgramTest.traceClrDataRegisterThroughMachineLayerToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[machine-clr-trace\]|\[m68k-step\]"

--- a/tools/machine-not-trace.sh
+++ b/tools/machine-not-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.integration.SmallProgramTest.traceNotDataRegisterThroughMachineLayerToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[machine-not-trace\]|\[m68k-step\]"

--- a/tools/machine-ori-trace.sh
+++ b/tools/machine-ori-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.integration.SmallProgramTest.traceOriImmediateToDataRegisterThroughMachineLayerToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[machine-ori-trace\]|\[m68k-step\]"

--- a/tools/not-trace.sh
+++ b/tools/not-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.cpu.m68k.M68kCpuStepTest.traceNotDataRegisterPipelineToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[not-trace\]|\[m68k-step\]"

--- a/tools/ori-trace.sh
+++ b/tools/ori-trace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle --no-daemon test --rerun-tasks \
+  --tests "com.JMPE.cpu.m68k.M68kCpuStepTest.traceOriImmediateToDataRegisterPipelineToConsole" \
+  --info --console=plain 2>&1 | grep -E "\[ori-trace\]|\[m68k-step\]"


### PR DESCRIPTION
Add CLR, NOT, and ORI runtime adapters plus dispatch registration, focused unit tests, CPU/machine end-to-end coverage, and trace helpers. This brings the built-in pipeline-backed instruction set to NOP, CLR, NOT, ORI, and TST.