### PR TITLE
Feat: complete Phase 3 decoder coverage

### DIFF
--- a/src/main/java/com/JMPE/cpu/m68k/Decoder.java
+++ b/src/main/java/com/JMPE/cpu/m68k/Decoder.java
@@ -1304,9 +1304,22 @@ public final class Decoder {
      * Bits 7:6 = 00 and specific EA encoding → SBCD.
      * Otherwise → OR Dn,<ea> or OR <ea>,Dn (direction from bit 8).
      */
-    private DecodedInstruction decodeLine8(int op, Bus bus, int extPc) {
-        // TODO: implement
-        throw new RuntimeException("Not implemented");
+    private DecodedInstruction decodeLine8(int op, Bus bus, int extPc) throws IllegalInstructionException {
+        int opwordAddr = extPc - 2;
+        int sizeBits = sizeBits(op);
+        int mode = eaMode(op);
+
+        if (sizeBits == 0b11) {
+            return decodeWordMultiplyOrDivide((op & 0x0100) != 0 ? Opcode.DIVS : Opcode.DIVU, op, bus, extPc);
+        }
+        if (directionToEa(op) && mode < 0b010) {
+            if (sizeBits == 0b00) {
+                return decodeBcdRegisterOrPredecrement(Opcode.SBCD, op, opwordAddr, extPc);
+            }
+            throw new IllegalInstructionException(op, opwordAddr);
+        }
+
+        return decodeRegisterEaBinaryOp(Opcode.OR, op, bus, extPc);
     }
 
     /**
@@ -1316,9 +1329,18 @@ public final class Decoder {
      * follows a different encoding than the normal 2-bit size field).
      * SUBX is distinguished by bit 8 = 1 with bits 5:3 = 000 (register) or 001 (memory).
      */
-    private DecodedInstruction decodeLine9(int op, Bus bus, int extPc) {
-        // TODO: implement
-        throw new RuntimeException("Not implemented");
+    private DecodedInstruction decodeLine9(int op, Bus bus, int extPc) throws IllegalInstructionException {
+        int sizeBits = sizeBits(op);
+        int mode = eaMode(op);
+
+        if (sizeBits == 0b11) {
+            return decodeAddressRegisterBinaryOp(Opcode.SUBA, op, bus, extPc);
+        }
+        if (directionToEa(op) && mode < 0b010) {
+            return decodeAddSubX(Opcode.SUBX, op, extPc - 2, extPc);
+        }
+
+        return decodeRegisterEaBinaryOp(Opcode.SUB, op, bus, extPc);
     }
 
     /**
@@ -1351,8 +1373,44 @@ public final class Decoder {
      * Bits 7:6 = 11 → CMPA. Bit 8 = 1 (and not CMPM) → EOR. Bit 8 = 0 → CMP.
      */
     private DecodedInstruction decodeLineB(int op, Bus bus, int extPc) throws IllegalInstructionException {
-        // Currently unimplemented: report as illegal instead of crashing with RuntimeException.
-        throw new IllegalInstructionException(op, extPc);
+        int opwordAddr = extPc - 2;
+        int sizeBits = sizeBits(op);
+        int mode = eaMode(op);
+        int reg = regY(op);
+        int[] cursor = {extPc};
+
+        if (sizeBits == 0b11) {
+            return decodeAddressRegisterBinaryOp(Opcode.CMPA, op, bus, extPc);
+        }
+
+        Size size = decodeSize(sizeBits, op, opwordAddr);
+        if ((op & 0x0100) == 0) {
+            if (mode == 0b001) {
+                throw new IllegalInstructionException(op, opwordAddr);
+            }
+            EffectiveAddress src = decodeEa(mode, reg, size, bus, cursor);
+            return new DecodedInstruction(
+                Opcode.CMP,
+                size,
+                src,
+                EffectiveAddress.dataReg(regX(op)),
+                0,
+                cursor[0]
+            );
+        }
+
+        if (mode == 0b001) {
+            return decodeCmpm(op, opwordAddr, extPc);
+        }
+        EffectiveAddress dst = decodeEa(mode, reg, size, bus, cursor);
+        return new DecodedInstruction(
+            Opcode.EOR,
+            size,
+            EffectiveAddress.dataReg(regX(op)),
+            dst,
+            0,
+            cursor[0]
+        );
     }
 
     /**
@@ -1362,10 +1420,21 @@ public final class Decoder {
      * Bit 8 = 1 with specific patterns → EXG. Otherwise → AND.
      */
     private DecodedInstruction decodeLineC(int op, Bus bus, int extPc) throws IllegalInstructionException {
-        // AND/MUL/ABCD/EXG decoding is not yet implemented. Treat all Line C
-        // opwords as illegal so that the CPU can route them via the standard
-        // illegal-instruction exception vector instead of crashing the emulator.
-        throw new IllegalInstructionException(op, extPc);
+        int opwordAddr = extPc - 2;
+        int sizeBits = sizeBits(op);
+        int mode = eaMode(op);
+
+        if (sizeBits == 0b11) {
+            return decodeWordMultiplyOrDivide((op & 0x0100) != 0 ? Opcode.MULS : Opcode.MULU, op, bus, extPc);
+        }
+        if (directionToEa(op) && mode < 0b010) {
+            if (sizeBits == 0b00) {
+                return decodeBcdRegisterOrPredecrement(Opcode.ABCD, op, opwordAddr, extPc);
+            }
+            return decodeExg(op, opwordAddr, extPc);
+        }
+
+        return decodeRegisterEaBinaryOp(Opcode.AND, op, bus, extPc);
     }
 
     /**
@@ -1374,9 +1443,18 @@ public final class Decoder {
      * <p>Mirror of Line 9 (SUB). Same structural rules apply; see
      * {@link #decodeLine9} comments.
      */
-    private DecodedInstruction decodeLineD(int op, Bus bus, int extPc) {
-        // TODO: implement
-        throw new RuntimeException("Not implemented");
+    private DecodedInstruction decodeLineD(int op, Bus bus, int extPc) throws IllegalInstructionException {
+        int sizeBits = sizeBits(op);
+        int mode = eaMode(op);
+
+        if (sizeBits == 0b11) {
+            return decodeAddressRegisterBinaryOp(Opcode.ADDA, op, bus, extPc);
+        }
+        if (directionToEa(op) && mode < 0b010) {
+            return decodeAddSubX(Opcode.ADDX, op, extPc - 2, extPc);
+        }
+
+        return decodeRegisterEaBinaryOp(Opcode.ADD, op, bus, extPc);
     }
 
     /**
@@ -1387,9 +1465,246 @@ public final class Decoder {
      * (11). For register shifts, bit 5 selects immediate count vs. register count,
      * and bits 4:3 encode the operation type (AS/LS/ROX/RO).
      */
-    private DecodedInstruction decodeLineE(int op, Bus bus, int extPc) {
-        // TODO: implement
-        throw new RuntimeException("Not implemented");
+    private DecodedInstruction decodeLineE(int op, Bus bus, int extPc) throws IllegalInstructionException {
+        if (sizeBits(op) == 0b11) {
+            return decodeMemoryShiftOrRotate(op, bus, extPc);
+        }
+        return decodeRegisterShiftOrRotate(op, extPc - 2, extPc);
+    }
+
+    private static DecodedInstruction decodeRegisterEaBinaryOp(
+        Opcode opcode, int op, Bus bus, int extPc) throws IllegalInstructionException {
+
+        int opwordAddr = extPc - 2;
+        Size size = decodeSize(sizeBits(op), op, opwordAddr);
+        int mode = eaMode(op);
+        int reg = regY(op);
+        int[] cursor = {extPc};
+
+        if (!directionToEa(op)) {
+            if (mode == 0b001) {
+                throw new IllegalInstructionException(op, opwordAddr);
+            }
+            EffectiveAddress src = decodeEa(mode, reg, size, bus, cursor);
+            return new DecodedInstruction(
+                opcode,
+                size,
+                src,
+                EffectiveAddress.dataReg(regX(op)),
+                0,
+                cursor[0]
+            );
+        }
+
+        EffectiveAddress dst = decodeEa(mode, reg, size, bus, cursor);
+        return new DecodedInstruction(
+            opcode,
+            size,
+            EffectiveAddress.dataReg(regX(op)),
+            dst,
+            0,
+            cursor[0]
+        );
+    }
+
+    private static DecodedInstruction decodeWordMultiplyOrDivide(
+        Opcode opcode, int op, Bus bus, int extPc) throws IllegalInstructionException {
+
+        int opwordAddr = extPc - 2;
+        if (eaMode(op) == 0b001) {
+            throw new IllegalInstructionException(op, opwordAddr);
+        }
+
+        int[] cursor = {extPc};
+        EffectiveAddress src = decodeEa(eaMode(op), regY(op), Size.WORD, bus, cursor);
+        return new DecodedInstruction(
+            opcode,
+            Size.WORD,
+            src,
+            EffectiveAddress.dataReg(regX(op)),
+            0,
+            cursor[0]
+        );
+    }
+
+    private static DecodedInstruction decodeAddressRegisterBinaryOp(
+        Opcode opcode, int op, Bus bus, int extPc) throws IllegalInstructionException {
+
+        int[] cursor = {extPc};
+        Size size = decodeSingleBitSize((op >>> 8) & 1);
+        EffectiveAddress src = decodeEa(eaMode(op), regY(op), size, bus, cursor);
+        return new DecodedInstruction(
+            opcode,
+            size,
+            src,
+            EffectiveAddress.addrReg(regX(op)),
+            0,
+            cursor[0]
+        );
+    }
+
+    private static DecodedInstruction decodeBcdRegisterOrPredecrement(
+        Opcode opcode, int op, int opwordAddr, int extPc) throws IllegalInstructionException {
+
+        return switch (eaMode(op)) {
+            case 0b000 -> new DecodedInstruction(
+                opcode,
+                Size.BYTE,
+                EffectiveAddress.dataReg(regY(op)),
+                EffectiveAddress.dataReg(regX(op)),
+                0,
+                extPc
+            );
+            case 0b001 -> new DecodedInstruction(
+                opcode,
+                Size.BYTE,
+                EffectiveAddress.addrRegIndPreDec(regY(op)),
+                EffectiveAddress.addrRegIndPreDec(regX(op)),
+                0,
+                extPc
+            );
+            default -> throw new IllegalInstructionException(op, opwordAddr);
+        };
+    }
+
+    private static DecodedInstruction decodeAddSubX(
+        Opcode opcode, int op, int opwordAddr, int extPc) throws IllegalInstructionException {
+
+        Size size = decodeSize(sizeBits(op), op, opwordAddr);
+        return switch (eaMode(op)) {
+            case 0b000 -> new DecodedInstruction(
+                opcode,
+                size,
+                EffectiveAddress.dataReg(regY(op)),
+                EffectiveAddress.dataReg(regX(op)),
+                0,
+                extPc
+            );
+            case 0b001 -> new DecodedInstruction(
+                opcode,
+                size,
+                EffectiveAddress.addrRegIndPreDec(regY(op)),
+                EffectiveAddress.addrRegIndPreDec(regX(op)),
+                0,
+                extPc
+            );
+            default -> throw new IllegalInstructionException(op, opwordAddr);
+        };
+    }
+
+    private static DecodedInstruction decodeCmpm(
+        int op, int opwordAddr, int extPc) throws IllegalInstructionException {
+
+        if (eaMode(op) != 0b001) {
+            throw new IllegalInstructionException(op, opwordAddr);
+        }
+
+        Size size = decodeSize(sizeBits(op), op, opwordAddr);
+        return new DecodedInstruction(
+            Opcode.CMPM,
+            size,
+            EffectiveAddress.addrRegIndPostInc(regY(op)),
+            EffectiveAddress.addrRegIndPostInc(regX(op)),
+            0,
+            extPc
+        );
+    }
+
+    private static DecodedInstruction decodeExg(
+        int op, int opwordAddr, int extPc) throws IllegalInstructionException {
+
+        int mode = eaMode(op);
+        int sizeBits = sizeBits(op);
+        EffectiveAddress src;
+        EffectiveAddress dst;
+
+        if (mode == 0b000 && sizeBits == 0b01) {
+            src = EffectiveAddress.dataReg(regX(op));
+            dst = EffectiveAddress.dataReg(regY(op));
+        } else if (mode == 0b001 && sizeBits == 0b01) {
+            src = EffectiveAddress.addrReg(regX(op));
+            dst = EffectiveAddress.addrReg(regY(op));
+        } else if (mode == 0b001 && sizeBits == 0b10) {
+            src = EffectiveAddress.dataReg(regX(op));
+            dst = EffectiveAddress.addrReg(regY(op));
+        } else {
+            throw new IllegalInstructionException(op, opwordAddr);
+        }
+
+        return new DecodedInstruction(
+            Opcode.EXG,
+            Size.LONG,
+            src,
+            dst,
+            0,
+            extPc
+        );
+    }
+
+    private static DecodedInstruction decodeRegisterShiftOrRotate(
+        int op, int opwordAddr, int extPc) throws IllegalInstructionException {
+
+        int operationBits = (op >>> 3) & 0x3;
+        boolean left = (op & 0x0100) != 0;
+        Opcode opcode = switch (operationBits) {
+            case 0b00 -> left ? Opcode.ASL : Opcode.ASR;
+            case 0b01 -> left ? Opcode.LSL : Opcode.LSR;
+            case 0b10 -> left ? Opcode.ROXL : Opcode.ROXR;
+            case 0b11 -> left ? Opcode.ROL : Opcode.ROR;
+            default -> throw new AssertionError("unreachable: operationBits=" + operationBits);
+        };
+
+        Size size = decodeSize(sizeBits(op), op, opwordAddr);
+        EffectiveAddress src;
+        if ((op & 0x0020) != 0) {
+            src = EffectiveAddress.dataReg(regX(op));
+        } else {
+            int count = regX(op);
+            src = EffectiveAddress.immediate(count == 0 ? 8 : count);
+        }
+
+        return new DecodedInstruction(
+            opcode,
+            size,
+            src,
+            EffectiveAddress.dataReg(regY(op)),
+            0,
+            extPc
+        );
+    }
+
+    private static DecodedInstruction decodeMemoryShiftOrRotate(
+        int op, Bus bus, int extPc) throws IllegalInstructionException {
+
+        int opwordAddr = extPc - 2;
+        int mode = eaMode(op);
+        int reg = regY(op);
+        if (mode < 0b010 || (mode == 0b111 && reg >= 0b010)) {
+            throw new IllegalInstructionException(op, opwordAddr);
+        }
+
+        Opcode opcode = switch ((op >>> 8) & 0x7) {
+            case 0b000 -> Opcode.ASR;
+            case 0b001 -> Opcode.ASL;
+            case 0b010 -> Opcode.LSR;
+            case 0b011 -> Opcode.LSL;
+            case 0b100 -> Opcode.ROXR;
+            case 0b101 -> Opcode.ROXL;
+            case 0b110 -> Opcode.ROR;
+            case 0b111 -> Opcode.ROL;
+            default -> throw new AssertionError("unreachable");
+        };
+
+        int[] cursor = {extPc};
+        EffectiveAddress dst = decodeEa(mode, reg, Size.WORD, bus, cursor);
+        return new DecodedInstruction(
+            opcode,
+            Size.WORD,
+            EffectiveAddress.none(),
+            dst,
+            0,
+            cursor[0]
+        );
     }
 
     /**

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/Opcode.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/Opcode.java
@@ -13,6 +13,7 @@ public enum Opcode {
     NEG, NEGX,
     MULS, MULU,
     DIVS, DIVU,
+    ABCD, SBCD,
     CMP, CMPA, CMPI, CMPM,
     CLR,
     EXT,

--- a/src/test/java/com/JMPE/cpu/m68k/DecoderDispatchReachabilityTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/DecoderDispatchReachabilityTest.java
@@ -1,0 +1,42 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.JMPE.bus.AddressSpace;
+import com.JMPE.bus.Ram;
+import com.JMPE.cpu.m68k.dispatch.DispatchTable;
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+class DecoderDispatchReachabilityTest {
+    @Test
+    void everyBuiltInDispatchHandlerIsReachableFromDecoder() {
+        Decoder decoder = new Decoder();
+        DispatchTable dispatchTable = new DispatchTable();
+        AddressSpace bus = new AddressSpace();
+        bus.addRegion(new Ram(0x1000, 0x4000));
+
+        EnumSet<Opcode> expected = EnumSet.noneOf(Opcode.class);
+        for (Opcode opcode : Opcode.values()) {
+            if (dispatchTable.hasHandler(opcode)) {
+                expected.add(opcode);
+            }
+        }
+
+        EnumSet<Opcode> reachable = EnumSet.noneOf(Opcode.class);
+        for (int opword = 0; opword <= 0xFFFF; opword++) {
+            try {
+                Opcode opcode = decoder.decode(opword, bus, 0x1002).opcode();
+                if (dispatchTable.hasHandler(opcode)) {
+                    reachable.add(opcode);
+                }
+            } catch (IllegalInstructionException | RuntimeException ignored) {
+            }
+        }
+
+        assertEquals(expected, reachable);
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/DecoderPhaseThreeRemainingTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/DecoderPhaseThreeRemainingTest.java
@@ -1,0 +1,104 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import org.junit.jupiter.api.Test;
+
+class DecoderPhaseThreeRemainingTest {
+    private static final int INSTRUCTION_PC = 0x1000;
+    private static final int EXTENSION_PC = INSTRUCTION_PC + 2;
+
+    private final Decoder decoder = new Decoder();
+
+    @Test
+    void decodesDivideForms() throws IllegalInstructionException {
+        assertDecoded(0x80C0, Opcode.DIVU, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(0));
+        assertDecoded(0x81C0, Opcode.DIVS, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(0));
+    }
+
+    @Test
+    void decodesSbcdRegisterAndPredecrementForms() throws IllegalInstructionException {
+        assertDecoded(0x8503, Opcode.SBCD, Size.BYTE, EffectiveAddress.dataReg(3), EffectiveAddress.dataReg(2));
+        assertDecoded(0x850B, Opcode.SBCD, Size.BYTE,
+            EffectiveAddress.addrRegIndPreDec(3), EffectiveAddress.addrRegIndPreDec(2));
+    }
+
+    @Test
+    void decodesSubaAndSubxForms() throws IllegalInstructionException {
+        assertDecoded(0x90C0, Opcode.SUBA, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.addrReg(0));
+        assertDecoded(0x91C0, Opcode.SUBA, Size.LONG, EffectiveAddress.dataReg(0), EffectiveAddress.addrReg(0));
+        assertDecoded(0x9704, Opcode.SUBX, Size.BYTE, EffectiveAddress.dataReg(4), EffectiveAddress.dataReg(3));
+        assertDecoded(0x970C, Opcode.SUBX, Size.BYTE,
+            EffectiveAddress.addrRegIndPreDec(4), EffectiveAddress.addrRegIndPreDec(3));
+    }
+
+    @Test
+    void decodesCmpaAndCmpmForms() throws IllegalInstructionException {
+        assertDecoded(0xB3CA, Opcode.CMPA, Size.LONG, EffectiveAddress.addrReg(2), EffectiveAddress.addrReg(1));
+        assertDecoded(0xB70D, Opcode.CMPM, Size.BYTE,
+            EffectiveAddress.addrRegIndPostInc(5), EffectiveAddress.addrRegIndPostInc(3));
+    }
+
+    @Test
+    void decodesMultiplyAbcdAndExgForms() throws IllegalInstructionException {
+        assertDecoded(0xC0C0, Opcode.MULU, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(0));
+        assertDecoded(0xC1C0, Opcode.MULS, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(0));
+        assertDecoded(0xC503, Opcode.ABCD, Size.BYTE, EffectiveAddress.dataReg(3), EffectiveAddress.dataReg(2));
+        assertDecoded(0xC50B, Opcode.ABCD, Size.BYTE,
+            EffectiveAddress.addrRegIndPreDec(3), EffectiveAddress.addrRegIndPreDec(2));
+        assertDecoded(0xC342, Opcode.EXG, Size.LONG, EffectiveAddress.dataReg(1), EffectiveAddress.dataReg(2));
+        assertDecoded(0xC54B, Opcode.EXG, Size.LONG, EffectiveAddress.addrReg(2), EffectiveAddress.addrReg(3));
+        assertDecoded(0xC38D, Opcode.EXG, Size.LONG, EffectiveAddress.dataReg(1), EffectiveAddress.addrReg(5));
+    }
+
+    @Test
+    void decodesAddaAndAddxForms() throws IllegalInstructionException {
+        assertDecoded(0xD0C0, Opcode.ADDA, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.addrReg(0));
+        assertDecoded(0xD1C0, Opcode.ADDA, Size.LONG, EffectiveAddress.dataReg(0), EffectiveAddress.addrReg(0));
+        assertDecoded(0xD704, Opcode.ADDX, Size.BYTE, EffectiveAddress.dataReg(4), EffectiveAddress.dataReg(3));
+        assertDecoded(0xD70C, Opcode.ADDX, Size.BYTE,
+            EffectiveAddress.addrRegIndPreDec(4), EffectiveAddress.addrRegIndPreDec(3));
+    }
+
+    @Test
+    void decodesRoxRegisterForms() throws IllegalInstructionException {
+        assertDecoded(0xE292, Opcode.ROXR, Size.LONG, EffectiveAddress.immediate(1), EffectiveAddress.dataReg(2));
+        assertDecoded(0xE332, Opcode.ROXL, Size.BYTE, EffectiveAddress.dataReg(1), EffectiveAddress.dataReg(2));
+    }
+
+    @Test
+    void decodesMemoryShiftAndRotateForms() throws IllegalInstructionException {
+        assertDecoded(0xE0D0, Opcode.ASR, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE1D0, Opcode.ASL, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE2D0, Opcode.LSR, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE3D0, Opcode.LSL, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE4D0, Opcode.ROXR, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE5D0, Opcode.ROXL, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE6D0, Opcode.ROR, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+        assertDecoded(0xE7D0, Opcode.ROL, Size.WORD, EffectiveAddress.none(), EffectiveAddress.addrRegInd(0));
+    }
+
+    @Test
+    void rejectsInvalidMemoryShiftRegisterDestination() {
+        assertThrows(IllegalInstructionException.class, () -> decoder.decode(0xE0C0, null, EXTENSION_PC));
+    }
+
+    private void assertDecoded(int opword,
+                               Opcode opcode,
+                               Size size,
+                               EffectiveAddress src,
+                               EffectiveAddress dst) throws IllegalInstructionException {
+        DecodedInstruction decoded = decoder.decode(opword, null, EXTENSION_PC);
+
+        assertEquals(opcode, decoded.opcode());
+        assertEquals(size, decoded.size());
+        assertEquals(src, decoded.src());
+        assertEquals(dst, decoded.dst());
+        assertEquals(0, decoded.extension());
+        assertEquals(EXTENSION_PC, decoded.nextPc());
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/DecoderPhaseThreeTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/DecoderPhaseThreeTest.java
@@ -1,0 +1,70 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
+import com.JMPE.cpu.m68k.instructions.Opcode;
+import org.junit.jupiter.api.Test;
+
+class DecoderPhaseThreeTest {
+    private static final int INSTRUCTION_PC = 0x1000;
+    private static final int EXTENSION_PC = INSTRUCTION_PC + 2;
+
+    private final Decoder decoder = new Decoder();
+
+    @Test
+    void decodesOrWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        assertDecoded(0x8240, Opcode.OR, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(1));
+    }
+
+    @Test
+    void decodesSubByteDataRegisterToDataRegister() throws IllegalInstructionException {
+        assertDecoded(0x9200, Opcode.SUB, Size.BYTE, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(1));
+    }
+
+    @Test
+    void decodesCmpWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        assertDecoded(0xB240, Opcode.CMP, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(1));
+    }
+
+    @Test
+    void decodesEorWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        assertDecoded(0xB340, Opcode.EOR, Size.WORD, EffectiveAddress.dataReg(1), EffectiveAddress.dataReg(0));
+    }
+
+    @Test
+    void decodesAndWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        assertDecoded(0xC240, Opcode.AND, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(1));
+    }
+
+    @Test
+    void decodesAddWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        assertDecoded(0xD240, Opcode.ADD, Size.WORD, EffectiveAddress.dataReg(0), EffectiveAddress.dataReg(1));
+    }
+
+    @Test
+    void decodesRegisterShiftAndRotateForms() throws IllegalInstructionException {
+        assertDecoded(0xE300, Opcode.ASL, Size.BYTE, EffectiveAddress.immediate(1), EffectiveAddress.dataReg(0));
+        assertDecoded(0xE222, Opcode.ASR, Size.BYTE, EffectiveAddress.dataReg(1), EffectiveAddress.dataReg(2));
+        assertDecoded(0xEB6C, Opcode.LSL, Size.WORD, EffectiveAddress.dataReg(5), EffectiveAddress.dataReg(4));
+        assertDecoded(0xE20B, Opcode.LSR, Size.BYTE, EffectiveAddress.immediate(1), EffectiveAddress.dataReg(3));
+        assertDecoded(0xE31B, Opcode.ROL, Size.BYTE, EffectiveAddress.immediate(1), EffectiveAddress.dataReg(3));
+        assertDecoded(0xE21B, Opcode.ROR, Size.BYTE, EffectiveAddress.immediate(1), EffectiveAddress.dataReg(3));
+    }
+
+    private void assertDecoded(int opword,
+                               Opcode opcode,
+                               Size size,
+                               EffectiveAddress src,
+                               EffectiveAddress dst) throws IllegalInstructionException {
+        DecodedInstruction decoded = decoder.decode(opword, null, EXTENSION_PC);
+
+        assertEquals(opcode, decoded.opcode());
+        assertEquals(size, decoded.size());
+        assertEquals(src, decoded.src());
+        assertEquals(dst, decoded.dst());
+        assertEquals(0, decoded.extension());
+        assertEquals(EXTENSION_PC, decoded.nextPc());
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuPhaseThreeStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuPhaseThreeStepTest.java
@@ -1,0 +1,217 @@
+package com.JMPE.cpu.m68k;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.JMPE.bus.AddressSpace;
+import com.JMPE.bus.Ram;
+import com.JMPE.cpu.m68k.dispatch.DispatchTable;
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+import org.junit.jupiter.api.Test;
+
+class M68kCpuPhaseThreeStepTest {
+    @Test
+    void stepExecutesOrWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 0x0F0F);
+        cpu.registers().setData(1, 0x00FF);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0x8240), new DispatchTable());
+
+        assertEquals(0x0FFF, cpu.registers().data(1));
+        assertEquals(0x1002, cpu.registers().programCounter());
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertFalse(cpu.statusRegister().isZeroSet());
+    }
+
+    @Test
+    void stepExecutesAndWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 0x0F0F);
+        cpu.registers().setData(1, 0x00FF);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xC240), new DispatchTable());
+
+        assertEquals(0x000F, cpu.registers().data(1));
+        assertEquals(0x1002, cpu.registers().programCounter());
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertFalse(cpu.statusRegister().isZeroSet());
+    }
+
+    @Test
+    void stepExecutesSubByteDataRegisterToDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 1);
+        cpu.registers().setData(1, 0);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0x9200), new DispatchTable());
+
+        assertEquals(0x0000_00FF, cpu.registers().data(1));
+        assertEquals(0x1002, cpu.registers().programCounter());
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertTrue(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    @Test
+    void stepExecutesAddWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 1);
+        cpu.registers().setData(1, 0x7FFF);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xD240), new DispatchTable());
+
+        assertEquals(0x0000_8000, cpu.registers().data(1));
+        assertEquals(0x1002, cpu.registers().programCounter());
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertTrue(cpu.statusRegister().isOverflowSet());
+    }
+
+    @Test
+    void stepExecutesCmpWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 0x1234);
+        cpu.registers().setData(1, 0x1234);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xB240), new DispatchTable());
+
+        assertEquals(0x1234, cpu.registers().data(1));
+        assertEquals(0x1002, cpu.registers().programCounter());
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isZeroSet());
+        assertFalse(cpu.statusRegister().isNegativeSet());
+    }
+
+    @Test
+    void stepExecutesEorWordDataRegisterToDataRegister() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 0x00FF);
+        cpu.registers().setData(1, 0x00F0);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xB340), new DispatchTable());
+
+        assertEquals(0x000F, cpu.registers().data(0));
+        assertEquals(0x1002, cpu.registers().programCounter());
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertFalse(cpu.statusRegister().isZeroSet());
+    }
+
+    @Test
+    void stepExecutesAslByteImmediate() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(0, 0x80);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xE300), new DispatchTable());
+
+        assertEquals(0x0000_0000, cpu.registers().data(0) & 0xFF);
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isZeroSet());
+        assertTrue(cpu.statusRegister().isOverflowSet());
+        assertTrue(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    @Test
+    void stepExecutesAsrByteWithRegisterCount() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(1, 1);
+        cpu.registers().setData(2, 0x80);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xE222), new DispatchTable());
+
+        assertEquals(0x0000_00C0, cpu.registers().data(2) & 0xFF);
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+    }
+
+    @Test
+    void stepExecutesLslWordWithRegisterCount() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(4, 0x4000);
+        cpu.registers().setData(5, 1);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xEB6C), new DispatchTable());
+
+        assertEquals(0x0000_8000, cpu.registers().data(4) & 0xFFFF);
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertFalse(cpu.statusRegister().isCarrySet());
+    }
+
+    @Test
+    void stepExecutesLsrByteImmediate() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(3, 0x01);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xE20B), new DispatchTable());
+
+        assertEquals(0x0000_0000, cpu.registers().data(3) & 0xFF);
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isZeroSet());
+        assertTrue(cpu.statusRegister().isCarrySet());
+        assertTrue(cpu.statusRegister().isExtendSet());
+    }
+
+    @Test
+    void stepExecutesRolByteImmediate() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(3, 0x80);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xE31B), new DispatchTable());
+
+        assertEquals(0x0000_0001, cpu.registers().data(3) & 0xFF);
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertFalse(cpu.statusRegister().isNegativeSet());
+        assertTrue(cpu.statusRegister().isCarrySet());
+    }
+
+    @Test
+    void stepExecutesRorByteImmediate() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x1000);
+        cpu.registers().setData(3, 0x01);
+
+        M68kCpu.StepReport report = cpu.step(busWithWords(0x1000, 0xE21B), new DispatchTable());
+
+        assertEquals(0x0000_0080, cpu.registers().data(3) & 0xFF);
+        assertTrue(report.success());
+        assertEquals(4, report.cycles());
+        assertTrue(cpu.statusRegister().isNegativeSet());
+        assertTrue(cpu.statusRegister().isCarrySet());
+    }
+
+    private static AddressSpace busWithWords(int baseAddress, int... words) {
+        AddressSpace bus = new AddressSpace();
+        bus.addRegion(new Ram(0x1000, 0x2000));
+        for (int index = 0; index < words.length; index++) {
+            bus.writeWord(baseAddress + (index * 2), words[index]);
+        }
+        return bus;
+    }
+}


### PR DESCRIPTION
## Summary
- finish the remaining Phase 3 line 8-E decoder families
- add decoder regression coverage for the newly decoded opcodes
- keep unsupported execution work deferred to the next phase instead of adding placeholder handlers

## Validation
- gradle --no-daemon test
- gradle --no-daemon build

## Next
- Phase 4: implement dispatch/execute support for the newly decoded families