### PR TITLE
fix: pre-commit (An)+ side-effects and CCR/SR masking (−40k conformance failures)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 
 # Logs
 *.log
+*.hprof
 
 # IDE files
 .idea/

--- a/README.md
+++ b/README.md
@@ -93,22 +93,44 @@ and `-Djmpe.boot.steps=32`. ROM binaries are not committed to this repository.
 
 ## Optional 68000 single-step conformance smoke tests
 If you clone `SingleStepTests/680x0` under `~/cpu-testdata/680x0`, the single-step smoke tests
-auto-detect `~/cpu-testdata/680x0/68000/v1` and run a bounded subset of the external corpus.
+auto-detect `~/cpu-testdata/680x0/68000/v1`. When enabled, `gradle test` now wires the full
+external `68000/v1` corpus through the focused add/move/branch suites plus sharded remaining-corpus suites.
 You can also point at another checkout explicitly:
 
 ```bash
+# Run the full external corpus with a bounded per-file sample
 gradle --no-daemon test \
   -Djmpe.680x0.enable=true \
   -Djmpe.680x0.dir=/path/to/680x0/68000/v1 \
+  -Djmpe.680x0.cases=25
+
+# Full-corpus runs disable Gradle XML/HTML reports by default to avoid heap blowups
+gradle --no-daemon test \
+  -Djmpe.680x0.enable=true \
+  -Djmpe.680x0.dir=/path/to/680x0/68000/v1 \
+  -Djmpe.680x0.cases=all
+
+# Or target one suite while debugging
+gradle --no-daemon test \
+  -Djmpe.680x0.enable=true \
+  -Djmpe.680x0.dir=/path/to/68000/v1 \
   -Djmpe.680x0.cases=25 \
-  --tests 'com.JMPE.cpu.Singlestep_Add_Test' \
-  --tests 'com.JMPE.cpu.Singlestep_Move_Test' \
-  --tests 'com.JMPE.cpu.Singlestep_Branch_Test'
+  --tests 'com.JMPE.cpu.Singlestep_Move_Test'
+
+# Or target one remaining-corpus shard while debugging the other upstream files
+gradle --no-daemon test \
+  -Djmpe.680x0.enable=true \
+  -Djmpe.680x0.dir=/path/to/68000/v1 \
+  -Djmpe.680x0.cases=25 \
+  --tests 'com.JMPE.cpu.Singlestep_Remaining_01_Test'
 ```
 
 Use `-Djmpe.680x0.cases=all` to remove the per-file case cap. By default the harness compares
 architected final CPU state and RAM writes for each one-instruction case; add
-`-Djmpe.680x0.cycles=true` to also assert cycle counts.
+`-Djmpe.680x0.cycles=true` to also assert cycle counts. Full `cases=all` runs now disable Gradle
+XML/HTML test reports by default to keep the test task from running out of heap while handling
+roughly one million dynamic cases; add `-Djmpe.680x0.reports=true` when you want report files for
+smaller targeted runs.
 
 ## Project layout
 ```text

--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ If you have a local Mac Plus ROM outside the repository, you can run a bounded b
 If you prefer running Gradle directly, the test also accepts `-Djmpe.rom=/path/to/mac-plus.rom`
 and `-Djmpe.boot.steps=32`. ROM binaries are not committed to this repository.
 
+## Optional 68000 single-step conformance smoke tests
+If you clone `SingleStepTests/680x0` under `~/cpu-testdata/680x0`, the single-step smoke tests
+auto-detect `~/cpu-testdata/680x0/68000/v1` and run a bounded subset of the external corpus.
+You can also point at another checkout explicitly:
+
+```bash
+gradle --no-daemon test \
+  -Djmpe.680x0.enable=true \
+  -Djmpe.680x0.dir=/path/to/680x0/68000/v1 \
+  -Djmpe.680x0.cases=25 \
+  --tests 'com.JMPE.cpu.Singlestep_Add_Test' \
+  --tests 'com.JMPE.cpu.Singlestep_Move_Test' \
+  --tests 'com.JMPE.cpu.Singlestep_Branch_Test'
+```
+
+Use `-Djmpe.680x0.cases=all` to remove the per-file case cap. By default the harness compares
+architected final CPU state and RAM writes for each one-instruction case; add
+`-Djmpe.680x0.cycles=true` to also assert cycle counts.
+
 ## Project layout
 ```text
 src/main/java/com/JMPE/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,34 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
     failOnNoDiscoveredTests = false
-    listOf("jmpe.rom", "jmpe.boot.steps", "jmpe.680x0.enable", "jmpe.680x0.dir", "jmpe.680x0.cases", "jmpe.680x0.cycles").forEach { key ->
+    listOf(
+        "jmpe.rom",
+        "jmpe.boot.steps",
+        "jmpe.680x0.enable",
+        "jmpe.680x0.dir",
+        "jmpe.680x0.cases",
+        "jmpe.680x0.cycles",
+        "jmpe.680x0.reports"
+    ).forEach { key ->
         System.getProperty(key)?.let { value ->
             systemProperty(key, value)
         }
+    }
+    val conformanceEnabled = System.getProperty("jmpe.680x0.enable")?.toBoolean() == true
+    val fullConformance = System.getProperty("jmpe.680x0.cases")
+        ?.trim()
+        ?.equals("all", ignoreCase = true) == true
+    val rawConformanceReports = System.getProperty("jmpe.680x0.reports")?.trim()
+    val conformanceReports = when {
+        rawConformanceReports == null || rawConformanceReports.isBlank() -> !fullConformance
+        rawConformanceReports.equals("true", ignoreCase = true) -> true
+        rawConformanceReports.equals("false", ignoreCase = true) -> false
+        else -> throw GradleException("jmpe.680x0.reports must be true or false")
+    }
+    if (conformanceEnabled) {
+        maxHeapSize = "2g"
+        forkEvery = 1
+        reports.html.required.set(conformanceReports)
+        reports.junitXml.required.set(conformanceReports)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ java {
 }
 
 dependencies {
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -24,7 +25,7 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
     failOnNoDiscoveredTests = false
-    listOf("jmpe.rom", "jmpe.boot.steps").forEach { key ->
+    listOf("jmpe.rom", "jmpe.boot.steps", "jmpe.680x0.enable", "jmpe.680x0.dir", "jmpe.680x0.cases", "jmpe.680x0.cycles").forEach { key ->
         System.getProperty(key)?.let { value ->
             systemProperty(key, value)
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8

--- a/src/main/java/com/JMPE/cpu/m68k/Decoder.java
+++ b/src/main/java/com/JMPE/cpu/m68k/Decoder.java
@@ -1261,8 +1261,9 @@ public final class Decoder {
      * <p>Bits 11:8 encode the condition (0000 = BRA, 0001 = BSR, others = Bcc).
      * The displacement is in the low byte of the opword; if it is $00 the
      * displacement is a full signed 16-bit word in the next extension word.
-     * If it is $FF (MC68020+), it is a 32-bit displacement — the 68000 used
-     * only in the Mac Plus does not support this, so treat $FF as illegal.
+     * On the 68000 every non-zero low byte is still a normal signed 8-bit
+     * displacement, including $FF which means -1. The long-displacement
+     * sentinel was added on later 68k parts and does not apply here.
      *
      * <p>This is a good example of why the Decoder must read extension words:
      * the branch target cannot be known without consuming the displacement word
@@ -1279,9 +1280,6 @@ public final class Decoder {
             displacementSize = Size.WORD;
             displacement = readExtWord(bus, cursor);
         } else {
-            if (displacementByte == 0xFF) {
-                throw new IllegalInstructionException(op, opwordAddr);
-            }
             displacementSize = Size.BYTE;
             displacement = (byte) displacementByte;
         }

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -189,7 +189,7 @@ public final class M68kCpu {
         } catch (RuntimeException exception) {
             if (exception instanceof Group0Fault group0Fault) {
                 int savedProgramCounter = group0Fault.savedProgramCounter(
-                    savedGroup0ProgramCounter(before, group0AccessPhase)
+                    savedGroup0ProgramCounter(before, registers.programCounter(), group0AccessPhase)
                 );
                 ExceptionDispatcher.dispatchGroup0Fault(
                     this,
@@ -298,8 +298,13 @@ public final class M68kCpu {
         return executeStepWithReport(instructionName, stepExecutor, System.out::println);
     }
 
-    private static int savedGroup0ProgramCounter(StepSnapshot before, Group0AccessPhase group0AccessPhase) {
-        return before.programCounter();
+    private static int savedGroup0ProgramCounter(StepSnapshot before,
+                                                 int currentProgramCounter,
+                                                 Group0AccessPhase group0AccessPhase) {
+        return switch (group0AccessPhase) {
+            case EXECUTE -> currentProgramCounter - Size.WORD.bytes();
+            default -> before.programCounter();
+        };
     }
 
     private static boolean isSupervisorSet(int rawStatusRegister) {

--- a/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
+++ b/src/main/java/com/JMPE/cpu/m68k/M68kCpu.java
@@ -188,13 +188,16 @@ public final class M68kCpu {
             throw exception;
         } catch (RuntimeException exception) {
             if (exception instanceof Group0Fault group0Fault) {
+                int savedProgramCounter = group0Fault.savedProgramCounter(
+                    savedGroup0ProgramCounter(before, group0AccessPhase)
+                );
                 ExceptionDispatcher.dispatchGroup0Fault(
                     this,
                     bus,
                     group0Fault,
-                    savedGroup0ProgramCounter(before, group0AccessPhase),
+                    savedProgramCounter,
                     opcodeFetched ? opword : 0,
-                    group0AccessPhase != Group0AccessPhase.EXECUTE,
+                    group0AccessPhase != Group0AccessPhase.EXECUTE || group0Fault.instructionAccess(),
                     isSupervisorSet(before.statusRegister())
                 );
                 if (!opcodeFetched && group0AccessPhase == Group0AccessPhase.OPCODE_FETCH) {
@@ -296,10 +299,7 @@ public final class M68kCpu {
     }
 
     private static int savedGroup0ProgramCounter(StepSnapshot before, Group0AccessPhase group0AccessPhase) {
-        return switch (group0AccessPhase) {
-            case OPCODE_FETCH -> before.programCounter();
-            case EXTENSION_FETCH, EXECUTE -> before.programCounter() + 2;
-        };
+        return before.programCounter();
     }
 
     private static boolean isSupervisorSet(int rawStatusRegister) {

--- a/src/main/java/com/JMPE/cpu/m68k/StatusRegister.java
+++ b/src/main/java/com/JMPE/cpu/m68k/StatusRegister.java
@@ -49,11 +49,11 @@ public final class StatusRegister {
     }
 
     public int conditionCodeRegister() {
-        return rawValue() & 0xFF;
+        return rawValue() & 0x1F;
     }
 
     public void setConditionCodeRegister(int ccr) {
-        value = (rawValue() & 0xFF00) | (ccr & 0xFF);
+        value = (rawValue() & 0xFF00) | (ccr & 0x1F);
     }
 
     public int interruptMask() {

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/BccOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/BccOp.java
@@ -26,7 +26,7 @@ public final class BccOp implements Op {
             DispatchSupport.branchBase(cpu, decoded.size()),
             displacement.value(),
             DispatchSupport.conditionCodesReader(cpu),
-            cpu.registers()::setProgramCounter
+            DispatchSupport.controlTransferPcWriter(cpu)
         );
     }
 

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/BraOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/BraOp.java
@@ -25,7 +25,7 @@ public final class BraOp implements Op {
         return Bra.execute(
             DispatchSupport.branchBase(cpu, decoded.size()),
             displacement.value(),
-            cpu.registers()::setProgramCounter
+            DispatchSupport.controlTransferPcWriter(cpu)
         );
     }
 

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/BsrOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/BsrOp.java
@@ -29,7 +29,7 @@ public final class BsrOp implements Op {
             displacement.value(),
             returnAddress,
             value -> DispatchSupport.pushLong(cpu, bus, value),
-            cpu.registers()::setProgramCounter
+            DispatchSupport.controlTransferPcWriter(cpu)
         );
     }
 

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/DbccOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/DbccOp.java
@@ -29,7 +29,7 @@ public final class DbccOp implements Op {
             () -> cpu.registers().data(counterRegister),
             value -> cpu.registers().setData(counterRegister, value),
             DispatchSupport.conditionCodesReader(cpu),
-            cpu.registers()::setProgramCounter
+            DispatchSupport.controlTransferPcWriter(cpu)
         );
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchSupport.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/DispatchSupport.java
@@ -5,9 +5,11 @@ import com.JMPE.cpu.m68k.EffectiveAddress;
 import com.JMPE.cpu.m68k.M68kCpu;
 import com.JMPE.cpu.m68k.Registers;
 import com.JMPE.cpu.m68k.Size;
+import com.JMPE.cpu.m68k.exceptions.ProgramCounterAddressErrorException;
 import com.JMPE.cpu.m68k.exceptions.PrivilegeViolation;
 import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
 import com.JMPE.cpu.m68k.instructions.Opcode;
+import com.JMPE.cpu.m68k.instructions.common.PcWriter;
 import com.JMPE.cpu.m68k.instructions.control.Bcc;
 import com.JMPE.cpu.m68k.instructions.data.Move;
 import com.JMPE.cpu.m68k.instructions.data.Movem;
@@ -249,6 +251,23 @@ final class DispatchSupport {
             default -> throw new IllegalArgumentException(
                 "Branch displacement size must be BYTE or WORD but was " + displacementSize);
         };
+    }
+
+    static PcWriter controlTransferPcWriter(M68kCpu cpu) {
+        Objects.requireNonNull(cpu, "cpu must not be null");
+
+        return newPc -> {
+            if ((newPc & 1) != 0) {
+                throw new ProgramCounterAddressErrorException(newPc);
+            }
+            cpu.registers().setProgramCounter(newPc);
+        };
+    }
+
+    static void validateControlTransferTarget(int targetAddress) {
+        if ((targetAddress & 1) != 0) {
+            throw new ProgramCounterAddressErrorException(targetAddress);
+        }
     }
 
     static Bcc.ConditionCodesReader conditionCodesReader(M68kCpu cpu) {

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/JmpOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/JmpOp.java
@@ -20,6 +20,6 @@ public final class JmpOp implements Op {
         DispatchSupport.requireNoDestination(decoded, "JMP");
         DispatchSupport.requireNoExtension(decoded, "JMP");
 
-        return Jmp.execute(DispatchSupport.computeAddress(decoded.src(), cpu), cpu.registers()::setProgramCounter);
+        return Jmp.execute(DispatchSupport.computeAddress(decoded.src(), cpu), DispatchSupport.controlTransferPcWriter(cpu));
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/JsrOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/JsrOp.java
@@ -22,6 +22,7 @@ public final class JsrOp implements Op {
 
         int returnAddress = cpu.registers().programCounter();
         int targetAddress = DispatchSupport.computeAddress(decoded.src(), cpu);
+        DispatchSupport.validateControlTransferTarget(targetAddress);
         return Jsr.execute(
             returnAddress,
             targetAddress,

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/MovemMemToRegOp.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/MovemMemToRegOp.java
@@ -26,6 +26,7 @@ public final class MovemMemToRegOp implements Op {
         int startAddress = DispatchSupport.movemStartAddress(decoded.src(), cpu, decoded.size(), registerCount);
         int effectiveAddressRegister = DispatchSupport.movemEffectiveAddressRegister(decoded.src());
         Movem.AddressingMode addressingMode = DispatchSupport.movemAddressingMode(decoded.src());
+        DispatchSupport.applyMovemWriteback(decoded.src(), cpu, startAddress, decoded.size(), registerCount);
         int cycles = Movem.executeMemoryToRegisters(
             decoded.size(),
             addressingMode,
@@ -39,7 +40,6 @@ public final class MovemMemToRegOp implements Op {
             },
             (registerIndex, value) -> DispatchSupport.writeMovemRegister(cpu, registerIndex, value)
         );
-        DispatchSupport.applyMovemWriteback(decoded.src(), cpu, startAddress, decoded.size(), registerCount);
         return cycles;
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/dispatch/OperandResolver.java
+++ b/src/main/java/com/JMPE/cpu/m68k/dispatch/OperandResolver.java
@@ -76,9 +76,8 @@ public final class OperandResolver {
 
             case EffectiveAddress.AddrRegIndPostInc(int reg) -> {
                 int addr = regs.address(reg);
-                int val = busRead(bus, addr, size);
                 regs.setAddress(reg, addr + increment(reg, size));
-                yield val;
+                yield busRead(bus, addr, size);
             }
 
             case EffectiveAddress.AddrRegIndPreDec(int reg) -> {
@@ -147,8 +146,8 @@ public final class OperandResolver {
 
             case EffectiveAddress.AddrRegIndPostInc(int reg) -> {
                 int addr = regs.address(reg);
-                busWrite(bus, addr, size, value);
                 regs.setAddress(reg, addr + increment(reg, size));
+                busWrite(bus, addr, size, value);
             }
 
             case EffectiveAddress.AddrRegIndPreDec(int reg) -> {
@@ -227,11 +226,11 @@ public final class OperandResolver {
             case EffectiveAddress.AddrRegIndPostInc(int reg) -> {
                 int addr = regs.address(reg);
                 int inc = increment(reg, size);
+                regs.setAddress(reg, addr + inc);
                 yield new Location() {
                     @Override public int read() { return busRead(bus, addr, size); }
                     @Override public void write(int value) {
                         busWrite(bus, addr, size, value);
-                        regs.setAddress(reg, addr + inc);
                     }
                 };
             }

--- a/src/main/java/com/JMPE/cpu/m68k/exceptions/ExceptionDispatcher.java
+++ b/src/main/java/com/JMPE/cpu/m68k/exceptions/ExceptionDispatcher.java
@@ -6,8 +6,8 @@ import com.JMPE.cpu.m68k.M68kCpu;
 import java.util.Objects;
 
 public final class ExceptionDispatcher {
-    private static final int GROUP0_INSTRUCTION_ACCESS = 0;
-    private static final int GROUP0_DATA_ACCESS = 0x08;
+    private static final int GROUP0_DATA_ACCESS = 0;
+    private static final int GROUP0_INSTRUCTION_ACCESS = 0x08;
     private static final int GROUP0_READ = 0x10;
     private static final int GROUP0_WRITE = 0;
     private static final int USER_DATA_FUNCTION_CODE = 0x01;
@@ -90,7 +90,7 @@ public final class ExceptionDispatcher {
         cpu.registers().setStackPointer(stackPointer);
         bus.writeWord(
             stackPointer,
-            buildGroup0StatusWord(fault.accessType(), instructionAccess, supervisorAccess)
+            buildGroup0StatusWord(instructionRegister, fault.accessType(), instructionAccess, supervisorAccess)
         );
 
         cpu.registers().setProgramCounter(bus.readLong(fault.exceptionVector().vectorAddress()));
@@ -146,17 +146,25 @@ public final class ExceptionDispatcher {
         cpu.recordExceptionFrame(ExceptionFrameKind.SIX_BYTE_SIMPLE);
     }
 
-    private static int buildGroup0StatusWord(FaultAccessType accessType,
+    private static int buildGroup0StatusWord(int instructionRegister,
+                                             FaultAccessType accessType,
+                                             boolean instructionAccess,
+                                             boolean supervisorAccess) {
+        return (instructionRegister & 0xFFE0)
+            | buildGroup0StatusBits(accessType, instructionAccess, supervisorAccess);
+    }
+
+    private static int buildGroup0StatusBits(FaultAccessType accessType,
                                              boolean instructionAccess,
                                              boolean supervisorAccess) {
         int readWrite = accessType == FaultAccessType.READ ? GROUP0_READ : GROUP0_WRITE;
-        int instructionNot = instructionAccess ? GROUP0_INSTRUCTION_ACCESS : GROUP0_DATA_ACCESS;
+        int instructionData = instructionAccess ? GROUP0_INSTRUCTION_ACCESS : GROUP0_DATA_ACCESS;
         int functionCode;
         if (supervisorAccess) {
             functionCode = instructionAccess ? SUPERVISOR_PROGRAM_FUNCTION_CODE : SUPERVISOR_DATA_FUNCTION_CODE;
         } else {
             functionCode = instructionAccess ? USER_PROGRAM_FUNCTION_CODE : USER_DATA_FUNCTION_CODE;
         }
-        return readWrite | instructionNot | functionCode;
+        return readWrite | instructionData | functionCode;
     }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/exceptions/Group0Fault.java
+++ b/src/main/java/com/JMPE/cpu/m68k/exceptions/Group0Fault.java
@@ -9,4 +9,12 @@ public interface Group0Fault {
     int faultAddress();
 
     FaultAccessType accessType();
+
+    default boolean instructionAccess() {
+        return false;
+    }
+
+    default int savedProgramCounter(int defaultSavedProgramCounter) {
+        return defaultSavedProgramCounter;
+    }
 }

--- a/src/main/java/com/JMPE/cpu/m68k/exceptions/ProgramCounterAddressErrorException.java
+++ b/src/main/java/com/JMPE/cpu/m68k/exceptions/ProgramCounterAddressErrorException.java
@@ -1,0 +1,27 @@
+package com.JMPE.cpu.m68k.exceptions;
+
+/**
+ * Address error raised by a control transfer that tries to load an odd program counter.
+ */
+public final class ProgramCounterAddressErrorException extends AddressErrorException {
+    private final int savedProgramCounter;
+
+    public ProgramCounterAddressErrorException(int programCounter) {
+        this(programCounter, programCounter - Integer.BYTES);
+    }
+
+    public ProgramCounterAddressErrorException(int programCounter, int savedProgramCounter) {
+        super(programCounter, FaultAccessType.READ);
+        this.savedProgramCounter = savedProgramCounter;
+    }
+
+    @Override
+    public boolean instructionAccess() {
+        return true;
+    }
+
+    @Override
+    public int savedProgramCounter(int defaultSavedProgramCounter) {
+        return savedProgramCounter;
+    }
+}

--- a/src/main/java/com/JMPE/cpu/m68k/instructions/data/Move.java
+++ b/src/main/java/com/JMPE/cpu/m68k/instructions/data/Move.java
@@ -59,8 +59,8 @@ public final class Move {
         }
 
         int maskedResult = size.mask(sourceValue);
-        destinationWriter.accept(maskedResult);
         updateConditionCodes(maskedResult, size, conditionCodes);
+        destinationWriter.accept(maskedResult);
         return cycles;
     }
 

--- a/src/test/java/com/JMPE/cpu/SinglestepCorpusFiles.java
+++ b/src/test/java/com/JMPE/cpu/SinglestepCorpusFiles.java
@@ -1,0 +1,70 @@
+package com.JMPE.cpu;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+final class SinglestepCorpusFiles {
+    static final List<String> ADD_FILES = List.of(
+        "ADD.b.json.gz",
+        "ADD.w.json.gz",
+        "ADD.l.json.gz",
+        "ADDA.w.json.gz",
+        "ADDA.l.json.gz",
+        "ADDX.b.json.gz",
+        "ADDX.w.json.gz",
+        "ADDX.l.json.gz"
+    );
+
+    static final List<String> MOVE_FILES = List.of(
+        "MOVE.b.json.gz",
+        "MOVE.w.json.gz",
+        "MOVE.l.json.gz",
+        "MOVE.q.json.gz",
+        "MOVEA.w.json.gz",
+        "MOVEA.l.json.gz",
+        "MOVEM.w.json.gz",
+        "MOVEM.l.json.gz",
+        "MOVEP.w.json.gz",
+        "MOVEP.l.json.gz"
+    );
+
+    static final List<String> BRANCH_FILES = List.of(
+        "Bcc.json.gz",
+        "BSR.json.gz",
+        "DBcc.json.gz",
+        "JMP.json.gz",
+        "JSR.json.gz"
+    );
+
+    private static final Set<String> WIRED_FILE_SET = Stream.of(ADD_FILES, MOVE_FILES, BRANCH_FILES)
+        .collect(LinkedHashSet::new, LinkedHashSet::addAll, LinkedHashSet::addAll);
+
+    private SinglestepCorpusFiles() {
+    }
+
+    static List<String> remainingFiles(Path corpusDirectory) {
+        Objects.requireNonNull(corpusDirectory, "corpusDirectory must not be null");
+
+        try (Stream<Path> paths = Files.list(corpusDirectory)) {
+            return paths
+                .filter(Files::isRegularFile)
+                .map(path -> path.getFileName().toString())
+                .filter(fileName -> fileName.endsWith(".json.gz"))
+                .filter(fileName -> !WIRED_FILE_SET.contains(fileName))
+                .sorted()
+                .toList();
+        } catch (IOException exception) {
+            throw new UncheckedIOException(
+                "Failed to enumerate single-step corpus files in " + corpusDirectory.toAbsolutePath().normalize(),
+                exception
+            );
+        }
+    }
+}

--- a/src/test/java/com/JMPE/cpu/SinglestepTestSupport.java
+++ b/src/test/java/com/JMPE/cpu/SinglestepTestSupport.java
@@ -1,0 +1,45 @@
+package com.JMPE.cpu;
+
+import com.JMPE.harness.CpuStateAdapter;
+import com.JMPE.harness.MemoryAsserts;
+import com.JMPE.harness.SingleStepLoader;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+final class SinglestepTestSupport {
+    private SinglestepTestSupport() {
+    }
+
+    static Path requireCorpusDirectory() {
+        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
+        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
+        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
+        return corpusDirectory.get();
+    }
+
+    static Stream<DynamicNode> dynamicTests(Path corpusDirectory, List<String> fileNames) {
+        return fileNames.stream()
+            .map(fileName -> DynamicContainer.dynamicContainer(
+                fileName,
+                dynamicTestsForFile(corpusDirectory, fileName)
+            ));
+    }
+
+    private static Stream<DynamicTest> dynamicTestsForFile(Path corpusDirectory, String fileName) {
+        return SingleStepLoader.loadCaseSpecs(corpusDirectory, fileName)
+            .stream()
+            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
+                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
+                CpuStateAdapter.assertArchitectedState(caseSpec, result);
+                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
+            }));
+    }
+}

--- a/src/test/java/com/JMPE/cpu/Singlestep_Add_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Add_Test.java
@@ -1,4 +1,42 @@
 package com.JMPE.cpu;
 
-public class Singlestep_Add_Test {
+import com.JMPE.harness.CpuStateAdapter;
+import com.JMPE.harness.MemoryAsserts;
+import com.JMPE.harness.SingleStepLoader;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class Singlestep_Add_Test {
+    private static final List<String> FILES = List.of(
+        "ADD.b.json.gz",
+        "ADD.w.json.gz",
+        "ADD.l.json.gz",
+        "ADDA.w.json.gz",
+        "ADDA.l.json.gz",
+        "ADDX.b.json.gz",
+        "ADDX.w.json.gz",
+        "ADDX.l.json.gz"
+    );
+
+    @TestFactory
+    Stream<DynamicTest> runsAddFamilySmokeCasesFromExternalCorpus() {
+        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
+        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
+        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
+
+        return SingleStepLoader.loadCaseSpecs(corpusDirectory.get(), FILES.toArray(String[]::new))
+            .stream()
+            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
+                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
+                CpuStateAdapter.assertArchitectedState(caseSpec, result);
+                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
+            }));
+    }
 }

--- a/src/test/java/com/JMPE/cpu/Singlestep_Add_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Add_Test.java
@@ -1,42 +1,15 @@
 package com.JMPE.cpu;
 
-import com.JMPE.harness.CpuStateAdapter;
-import com.JMPE.harness.MemoryAsserts;
-import com.JMPE.harness.SingleStepLoader;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 class Singlestep_Add_Test {
-    private static final List<String> FILES = List.of(
-        "ADD.b.json.gz",
-        "ADD.w.json.gz",
-        "ADD.l.json.gz",
-        "ADDA.w.json.gz",
-        "ADDA.l.json.gz",
-        "ADDX.b.json.gz",
-        "ADDX.w.json.gz",
-        "ADDX.l.json.gz"
-    );
-
     @TestFactory
-    Stream<DynamicTest> runsAddFamilySmokeCasesFromExternalCorpus() {
-        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
-        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
-        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
-
-        return SingleStepLoader.loadCaseSpecs(corpusDirectory.get(), FILES.toArray(String[]::new))
-            .stream()
-            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
-                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
-                CpuStateAdapter.assertArchitectedState(caseSpec, result);
-                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
-            }));
+    Stream<DynamicNode> runsAddFamilySmokeCasesFromExternalCorpus() {
+        Path corpusDirectory = SinglestepTestSupport.requireCorpusDirectory();
+        return SinglestepTestSupport.dynamicTests(corpusDirectory, SinglestepCorpusFiles.ADD_FILES);
     }
 }

--- a/src/test/java/com/JMPE/cpu/Singlestep_Branch_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Branch_Test.java
@@ -1,4 +1,39 @@
 package com.JMPE.cpu;
 
-public class Singlestep_Branch_Test {
+import com.JMPE.harness.CpuStateAdapter;
+import com.JMPE.harness.MemoryAsserts;
+import com.JMPE.harness.SingleStepLoader;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class Singlestep_Branch_Test {
+    private static final List<String> FILES = List.of(
+        "Bcc.json.gz",
+        "BSR.json.gz",
+        "DBcc.json.gz",
+        "JMP.json.gz",
+        "JSR.json.gz"
+    );
+
+    @TestFactory
+    Stream<DynamicTest> runsBranchFamilySmokeCasesFromExternalCorpus() {
+        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
+        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
+        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
+
+        return SingleStepLoader.loadCaseSpecs(corpusDirectory.get(), FILES.toArray(String[]::new))
+            .stream()
+            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
+                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
+                CpuStateAdapter.assertArchitectedState(caseSpec, result);
+                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
+            }));
+    }
 }

--- a/src/test/java/com/JMPE/cpu/Singlestep_Branch_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Branch_Test.java
@@ -1,39 +1,15 @@
 package com.JMPE.cpu;
 
-import com.JMPE.harness.CpuStateAdapter;
-import com.JMPE.harness.MemoryAsserts;
-import com.JMPE.harness.SingleStepLoader;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 class Singlestep_Branch_Test {
-    private static final List<String> FILES = List.of(
-        "Bcc.json.gz",
-        "BSR.json.gz",
-        "DBcc.json.gz",
-        "JMP.json.gz",
-        "JSR.json.gz"
-    );
-
     @TestFactory
-    Stream<DynamicTest> runsBranchFamilySmokeCasesFromExternalCorpus() {
-        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
-        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
-        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
-
-        return SingleStepLoader.loadCaseSpecs(corpusDirectory.get(), FILES.toArray(String[]::new))
-            .stream()
-            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
-                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
-                CpuStateAdapter.assertArchitectedState(caseSpec, result);
-                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
-            }));
+    Stream<DynamicNode> runsBranchFamilySmokeCasesFromExternalCorpus() {
+        Path corpusDirectory = SinglestepTestSupport.requireCorpusDirectory();
+        return SinglestepTestSupport.dynamicTests(corpusDirectory, SinglestepCorpusFiles.BRANCH_FILES);
     }
 }

--- a/src/test/java/com/JMPE/cpu/Singlestep_Move_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Move_Test.java
@@ -1,44 +1,15 @@
 package com.JMPE.cpu;
 
-import com.JMPE.harness.CpuStateAdapter;
-import com.JMPE.harness.MemoryAsserts;
-import com.JMPE.harness.SingleStepLoader;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 class Singlestep_Move_Test {
-    private static final List<String> FILES = List.of(
-        "MOVE.b.json.gz",
-        "MOVE.w.json.gz",
-        "MOVE.l.json.gz",
-        "MOVE.q.json.gz",
-        "MOVEA.w.json.gz",
-        "MOVEA.l.json.gz",
-        "MOVEM.w.json.gz",
-        "MOVEM.l.json.gz",
-        "MOVEP.w.json.gz",
-        "MOVEP.l.json.gz"
-    );
-
     @TestFactory
-    Stream<DynamicTest> runsMoveFamilySmokeCasesFromExternalCorpus() {
-        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
-        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
-        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
-
-        return SingleStepLoader.loadCaseSpecs(corpusDirectory.get(), FILES.toArray(String[]::new))
-            .stream()
-            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
-                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
-                CpuStateAdapter.assertArchitectedState(caseSpec, result);
-                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
-            }));
+    Stream<DynamicNode> runsMoveFamilySmokeCasesFromExternalCorpus() {
+        Path corpusDirectory = SinglestepTestSupport.requireCorpusDirectory();
+        return SinglestepTestSupport.dynamicTests(corpusDirectory, SinglestepCorpusFiles.MOVE_FILES);
     }
 }

--- a/src/test/java/com/JMPE/cpu/Singlestep_Move_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Move_Test.java
@@ -1,4 +1,44 @@
 package com.JMPE.cpu;
 
-public class Singlestep_Move_Test {
+import com.JMPE.harness.CpuStateAdapter;
+import com.JMPE.harness.MemoryAsserts;
+import com.JMPE.harness.SingleStepLoader;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class Singlestep_Move_Test {
+    private static final List<String> FILES = List.of(
+        "MOVE.b.json.gz",
+        "MOVE.w.json.gz",
+        "MOVE.l.json.gz",
+        "MOVE.q.json.gz",
+        "MOVEA.w.json.gz",
+        "MOVEA.l.json.gz",
+        "MOVEM.w.json.gz",
+        "MOVEM.l.json.gz",
+        "MOVEP.w.json.gz",
+        "MOVEP.l.json.gz"
+    );
+
+    @TestFactory
+    Stream<DynamicTest> runsMoveFamilySmokeCasesFromExternalCorpus() {
+        assumeTrue(SingleStepLoader.isEnabled(), SingleStepLoader.disabledMessage());
+        Optional<Path> corpusDirectory = SingleStepLoader.findLocalCorpus();
+        assumeTrue(corpusDirectory.isPresent(), SingleStepLoader.missingCorpusMessage());
+
+        return SingleStepLoader.loadCaseSpecs(corpusDirectory.get(), FILES.toArray(String[]::new))
+            .stream()
+            .map(caseSpec -> DynamicTest.dynamicTest(caseSpec.displayName(), () -> {
+                CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
+                CpuStateAdapter.assertArchitectedState(caseSpec, result);
+                MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
+            }));
+    }
 }

--- a/src/test/java/com/JMPE/cpu/Singlestep_Remaining_Shards_Test.java
+++ b/src/test/java/com/JMPE/cpu/Singlestep_Remaining_Shards_Test.java
@@ -1,0 +1,110 @@
+package com.JMPE.cpu;
+
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.TestFactory;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+final class SinglestepRemainingShards {
+    private static final int SHARD_COUNT = 11;
+
+    private SinglestepRemainingShards() {
+    }
+
+    static Stream<DynamicNode> dynamicTests(int shardIndex) {
+        if (shardIndex < 0 || shardIndex >= SHARD_COUNT) {
+            throw new IllegalArgumentException("shardIndex must be in range 0.." + (SHARD_COUNT - 1));
+        }
+
+        Path corpusDirectory = SinglestepTestSupport.requireCorpusDirectory();
+        List<String> remainingFiles = SinglestepCorpusFiles.remainingFiles(corpusDirectory);
+        assumeTrue(!remainingFiles.isEmpty(), "No remaining external corpus files were found.");
+
+        int start = remainingFiles.size() * shardIndex / SHARD_COUNT;
+        int end = remainingFiles.size() * (shardIndex + 1) / SHARD_COUNT;
+        List<String> shardFiles = remainingFiles.subList(start, end);
+        assumeTrue(!shardFiles.isEmpty(), "No files were assigned to remaining shard " + shardIndex + ".");
+        return SinglestepTestSupport.dynamicTests(corpusDirectory, shardFiles);
+    }
+}
+
+class Singlestep_Remaining_01_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard01() {
+        return SinglestepRemainingShards.dynamicTests(0);
+    }
+}
+
+class Singlestep_Remaining_02_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard02() {
+        return SinglestepRemainingShards.dynamicTests(1);
+    }
+}
+
+class Singlestep_Remaining_03_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard03() {
+        return SinglestepRemainingShards.dynamicTests(2);
+    }
+}
+
+class Singlestep_Remaining_04_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard04() {
+        return SinglestepRemainingShards.dynamicTests(3);
+    }
+}
+
+class Singlestep_Remaining_05_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard05() {
+        return SinglestepRemainingShards.dynamicTests(4);
+    }
+}
+
+class Singlestep_Remaining_06_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard06() {
+        return SinglestepRemainingShards.dynamicTests(5);
+    }
+}
+
+class Singlestep_Remaining_07_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard07() {
+        return SinglestepRemainingShards.dynamicTests(6);
+    }
+}
+
+class Singlestep_Remaining_08_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard08() {
+        return SinglestepRemainingShards.dynamicTests(7);
+    }
+}
+
+class Singlestep_Remaining_09_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard09() {
+        return SinglestepRemainingShards.dynamicTests(8);
+    }
+}
+
+class Singlestep_Remaining_10_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard10() {
+        return SinglestepRemainingShards.dynamicTests(9);
+    }
+}
+
+class Singlestep_Remaining_11_Test {
+    @TestFactory
+    Stream<DynamicNode> runsRemainingCorpusShard11() {
+        return SinglestepRemainingShards.dynamicTests(10);
+    }
+}

--- a/src/test/java/com/JMPE/cpu/m68k/DecoderPhaseTwoTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/DecoderPhaseTwoTest.java
@@ -317,8 +317,37 @@ class DecoderPhaseTwoTest {
     }
 
     @Test
-    void rejectsLongBranchSentinelOn68000() {
-        assertThrows(IllegalInstructionException.class, () -> decoder.decode(0x60FF, null, EXTENSION_PC));
+    void decodesBraWithNegativeOneByteDisplacement() throws IllegalInstructionException {
+        DecodedInstruction decoded = decoder.decode(0x60FF, null, EXTENSION_PC);
+
+        assertEquals(Opcode.BRA, decoded.opcode());
+        assertEquals(Size.BYTE, decoded.size());
+        assertEquals(EffectiveAddress.immediate(-1), decoded.src());
+        assertEquals(EffectiveAddress.none(), decoded.dst());
+        assertEquals(EXTENSION_PC, decoded.nextPc());
+    }
+
+    @Test
+    void decodesBsrWithNegativeOneByteDisplacement() throws IllegalInstructionException {
+        DecodedInstruction decoded = decoder.decode(0x61FF, null, EXTENSION_PC);
+
+        assertEquals(Opcode.BSR, decoded.opcode());
+        assertEquals(Size.BYTE, decoded.size());
+        assertEquals(EffectiveAddress.immediate(-1), decoded.src());
+        assertEquals(EffectiveAddress.none(), decoded.dst());
+        assertEquals(EXTENSION_PC, decoded.nextPc());
+    }
+
+    @Test
+    void decodesBhiWithNegativeOneByteDisplacementAsGenericBcc() throws IllegalInstructionException {
+        DecodedInstruction decoded = decoder.decode(0x62FF, null, EXTENSION_PC);
+
+        assertEquals(Opcode.BCC, decoded.opcode());
+        assertEquals(Size.BYTE, decoded.size());
+        assertEquals(EffectiveAddress.immediate(-1), decoded.src());
+        assertEquals(EffectiveAddress.none(), decoded.dst());
+        assertEquals(0x2, decoded.extension());
+        assertEquals(EXTENSION_PC, decoded.nextPc());
     }
 
     private static AddressSpace busWithWords(int baseAddress, int... words) {

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -93,6 +93,9 @@ class M68kCpuStepTest {
     private static final int EORI_TO_SR_INITIAL_SR = 0xA71F;
     private static final int EORI_TO_SR_RESULT_SR = 0x87EF;
     private static final int EORI_TO_SR_USER_MODE_SR = 0x071F;
+    private static final int MOVE_W_D16_A4_D0 = 0x302C;
+    private static final int MOVEM_L_REG_TO_MEM_D16_A2 = 0x48EA;
+    private static final int MOVEM_MASK_D0 = 0x0001;
     private static final int CMPI_B_D0 = 0x0C00;
     private static final int CMPI_BYTE_IMMEDIATE = 0x0001;
     private static final int CMPI_BYTE_INITIAL = 0x1234_5600;
@@ -113,6 +116,9 @@ class M68kCpuStepTest {
     private static final int MOVE_USP_TO_A3 = 0x4E6B;
     private static final int LINE_A_0123 = 0xA123;
     private static final int LINE_F_0234 = 0xF234;
+    private static final int BRA_DISP_NEG13 = 0x60F3;
+    private static final int BSR_DISP_NEG1 = 0x61FF;
+    private static final int BCC_HI_DISP_NEG1 = 0x62FF;
     private static final int BCC_MI_DISP_37 = 0x6D25;
     private static final int BSR_DISP_NEG125 = 0x6183;
     private static final int JSR_A0 = 0x4E90;
@@ -120,9 +126,13 @@ class M68kCpuStepTest {
     private static final int TEST_SUPERVISOR_STACK_POINTER = 0x0000_2000;
     private static final int GROUP0_FRAME_WORD_USER_PROGRAM_READ = 0x001A;
     private static final int GROUP0_FRAME_WORD_SUPERVISOR_PROGRAM_READ = 0x001E;
+    private static final int GROUP0_FRAME_WORD_MOVE_SUPERVISOR_DATA_READ = 0x3035;
+    private static final int GROUP0_FRAME_WORD_MOVEM_SUPERVISOR_DATA_WRITE = 0x48E5;
     private static final int GROUP0_FRAME_WORD_TST_USER_DATA_READ = 0x4A51;
     private static final int GROUP0_FRAME_WORD_TST_SUPERVISOR_DATA_READ = 0x4A55;
+    private static final int GROUP0_FRAME_WORD_BRA_SUPERVISOR_PROGRAM_READ = 0x60FE;
     private static final int GROUP0_FRAME_WORD_BCC_SUPERVISOR_PROGRAM_READ = 0x6D3E;
+    private static final int GROUP0_FRAME_WORD_BSR_NEG1_SUPERVISOR_PROGRAM_READ = 0x61FE;
     private static final int GROUP0_FRAME_WORD_BSR_SUPERVISOR_PROGRAM_READ = 0x619E;
     private static final int GROUP0_FRAME_WORD_JSR_SUPERVISOR_PROGRAM_READ = 0x4E9E;
     private static final int TST_NEGATIVE_BYTE = 0x0000_0080;
@@ -1802,6 +1812,68 @@ class M68kCpuStepTest {
     }
 
     @Test
+    void stepVectorsBusErrorForUnmappedDataReadAfterExtensionFetchUsingLastExtensionWordPc() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        cpu.registers().setAddress(4, 0x0000_5000);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2703);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.BUS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, MOVE_W_D16_A4_D0);
+        bus.writeWord(0x0000_1002, 0x0000);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2703, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_MOVE_SUPERVISOR_DATA_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(0x0000_5000, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(MOVE_W_D16_A4_D0, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x2703, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
+        assertEquals(0x0000_1002, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=MOVE"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
+    void stepVectorsBusErrorForMovemWriteUsingLastExtensionWordPc() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        cpu.registers().setAddress(2, 0x0000_5000);
+        cpu.registers().setData(0, 0x1234_5678);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2705);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.BUS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, MOVEM_L_REG_TO_MEM_D16_A2);
+        bus.writeWord(0x0000_1002, MOVEM_MASK_D0);
+        bus.writeWord(0x0000_1004, 0x0000);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2705, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_MOVEM_SUPERVISOR_DATA_WRITE, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(0x0000_5000, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(MOVEM_L_REG_TO_MEM_D16_A2, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x2705, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
+        assertEquals(0x0000_1004, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=MOVEM_REG_TO_MEM"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
     void stepVectorsAddressErrorForOddBccTarget() throws IllegalInstructionException {
         M68kCpu cpu = new M68kCpu();
         cpu.registers().setProgramCounter(0x0000_1000);
@@ -1826,6 +1898,85 @@ class M68kCpuStepTest {
         assertEquals(0x0000_1023, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
         assertEquals(1, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=BCC"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
+    void stepVectorsAddressErrorForOddBraTarget() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2705);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.ADDRESS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, BRA_DISP_NEG13);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2705, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_BRA_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(0x0000_0FF5, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(BRA_DISP_NEG13, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x2705, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
+        assertEquals(0x0000_0FF1, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=BRA"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
+    void stepFallsThroughForUntakenBccWithNegativeOneByteDisplacement() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x271F);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        bus.writeWord(0x0000_1000, BCC_HI_DISP_NEG1);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(10, report.cycles());
+        assertEquals(0x0000_1002, cpu.registers().programCounter());
+        assertEquals(0x271F, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER, cpu.registers().supervisorStackPointer());
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=BCC"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001002"));
+    }
+
+    @Test
+    void stepVectorsAddressErrorForNegativeOneByteBsrTargetAfterPushingReturnAddress() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2707);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.ADDRESS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, BSR_DISP_NEG1);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2707, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 18, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_BSR_NEG1_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 18));
+        assertEquals(0x0000_1001, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 16));
+        assertEquals(BSR_DISP_NEG1, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(0x2707, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 10));
+        assertEquals(0x0000_0FFD, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x0000_1002, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=BSR"));
         assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
     }
 

--- a/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/M68kCpuStepTest.java
@@ -113,12 +113,18 @@ class M68kCpuStepTest {
     private static final int MOVE_USP_TO_A3 = 0x4E6B;
     private static final int LINE_A_0123 = 0xA123;
     private static final int LINE_F_0234 = 0xF234;
+    private static final int BCC_MI_DISP_37 = 0x6D25;
+    private static final int BSR_DISP_NEG125 = 0x6183;
+    private static final int JSR_A0 = 0x4E90;
     private static final int TEST_USER_STACK_POINTER = 0x0000_3000;
     private static final int TEST_SUPERVISOR_STACK_POINTER = 0x0000_2000;
-    private static final int GROUP0_SSW_USER_PROGRAM_READ = 0x0012;
-    private static final int GROUP0_SSW_SUPERVISOR_PROGRAM_READ = 0x0016;
-    private static final int GROUP0_SSW_USER_DATA_READ = 0x0019;
-    private static final int GROUP0_SSW_SUPERVISOR_DATA_READ = 0x001D;
+    private static final int GROUP0_FRAME_WORD_USER_PROGRAM_READ = 0x001A;
+    private static final int GROUP0_FRAME_WORD_SUPERVISOR_PROGRAM_READ = 0x001E;
+    private static final int GROUP0_FRAME_WORD_TST_USER_DATA_READ = 0x4A51;
+    private static final int GROUP0_FRAME_WORD_TST_SUPERVISOR_DATA_READ = 0x4A55;
+    private static final int GROUP0_FRAME_WORD_BCC_SUPERVISOR_PROGRAM_READ = 0x6D3E;
+    private static final int GROUP0_FRAME_WORD_BSR_SUPERVISOR_PROGRAM_READ = 0x619E;
+    private static final int GROUP0_FRAME_WORD_JSR_SUPERVISOR_PROGRAM_READ = 0x4E9E;
     private static final int TST_NEGATIVE_BYTE = 0x0000_0080;
     private static final int BCHG_D0_D1 = 0x0141;
     private static final int BTST_D0_D1 = 0x0101;
@@ -1545,8 +1551,8 @@ class M68kCpuStepTest {
         assertTrue(exceptionReport.success());
         assertTrue(rteReport.success());
         assertEquals(0x0000_1234, exceptionReport.after().programCounter());
-        assertEquals(0x0000_1002, rteReport.after().programCounter());
-        assertEquals(0x0000_1002, cpu.registers().programCounter());
+        assertEquals(0x0000_1000, rteReport.after().programCounter());
+        assertEquals(0x0000_1000, cpu.registers().programCounter());
         assertEquals(0x0015, cpu.statusRegister().rawValue());
         assertEquals(TEST_SUPERVISOR_STACK_POINTER, cpu.registers().supervisorStackPointer());
         assertEquals(TEST_USER_STACK_POINTER, cpu.registers().stackPointer());
@@ -1554,7 +1560,7 @@ class M68kCpuStepTest {
         assertEquals(2, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
         assertTrue(logs.get(1).contains("[m68k-step] OK op=RTE"));
-        assertTrue(logs.get(1).contains("pc=0x00001234->0x00001002"));
+        assertTrue(logs.get(1).contains("pc=0x00001234->0x00001000"));
     }
 
     @Test
@@ -1699,7 +1705,7 @@ class M68kCpuStepTest {
         assertEquals(0x0000_1234, cpu.registers().programCounter());
         assertEquals(0x2700, cpu.statusRegister().rawValue());
         assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
-        assertEquals(GROUP0_SSW_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(GROUP0_FRAME_WORD_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
         assertEquals(0x0000_1001, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
         assertEquals(0x0000, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
         assertEquals(0xA700, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
@@ -1727,7 +1733,7 @@ class M68kCpuStepTest {
         assertEquals(0x2000, cpu.statusRegister().rawValue());
         assertEquals(TEST_USER_STACK_POINTER, cpu.registers().userStackPointer());
         assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
-        assertEquals(GROUP0_SSW_USER_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(GROUP0_FRAME_WORD_USER_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
         assertEquals(0x0000_5000, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
         assertEquals(0x0000, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
         assertEquals(0x8000, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
@@ -1756,11 +1762,11 @@ class M68kCpuStepTest {
         assertEquals(0x0000_1234, cpu.registers().programCounter());
         assertEquals(0x2015, cpu.statusRegister().rawValue());
         assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
-        assertEquals(GROUP0_SSW_USER_DATA_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(GROUP0_FRAME_WORD_TST_USER_DATA_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
         assertEquals(0x0000_1235, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
         assertEquals(TST_W_A0, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
         assertEquals(0x0015, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
-        assertEquals(0x0000_1002, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(0x0000_1000, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
         assertEquals(1, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
         assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
@@ -1785,13 +1791,99 @@ class M68kCpuStepTest {
         assertEquals(0x0000_1234, cpu.registers().programCounter());
         assertEquals(0x2700, cpu.statusRegister().rawValue());
         assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
-        assertEquals(GROUP0_SSW_SUPERVISOR_DATA_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(GROUP0_FRAME_WORD_TST_SUPERVISOR_DATA_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
         assertEquals(0x0000_5000, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
         assertEquals(TST_W_A0, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
         assertEquals(0xA700, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
-        assertEquals(0x0000_1002, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(0x0000_1000, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
         assertEquals(1, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
+    void stepVectorsAddressErrorForOddBccTarget() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2708);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.ADDRESS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, BCC_MI_DISP_37);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2708, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_BCC_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(0x0000_1027, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(BCC_MI_DISP_37, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x2708, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
+        assertEquals(0x0000_1023, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=BCC"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
+    void stepVectorsAddressErrorForOddBsrTargetAfterPushingReturnAddress() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2706);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.ADDRESS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, BSR_DISP_NEG125);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2706, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 18, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_BSR_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 18));
+        assertEquals(0x0000_0F85, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 16));
+        assertEquals(BSR_DISP_NEG125, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(0x2706, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 10));
+        assertEquals(0x0000_0F81, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x0000_1002, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=BSR"));
+        assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
+    }
+
+    @Test
+    void stepVectorsAddressErrorForOddJsrTargetBeforePushingReturnAddress() throws IllegalInstructionException {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x0000_1000);
+        cpu.registers().setAddress(0, 0x0000_1021);
+        configureSplitStacks(cpu);
+        cpu.statusRegister().setRawValue(0x2710);
+        List<String> logs = new ArrayList<>();
+        AddressSpace bus = flatRamBus();
+        installVector(bus, ExceptionVector.ADDRESS_ERROR, 0x0000_1234);
+        bus.writeWord(0x0000_1000, JSR_A0);
+
+        M68kCpu.StepReport report = cpu.step(bus, new DispatchTable(), logs::add);
+
+        assertTrue(report.success());
+        assertEquals(0, report.cycles());
+        assertEquals(0x0000_1234, cpu.registers().programCounter());
+        assertEquals(0x2710, cpu.statusRegister().rawValue());
+        assertEquals(TEST_SUPERVISOR_STACK_POINTER - 14, cpu.registers().supervisorStackPointer());
+        assertEquals(GROUP0_FRAME_WORD_JSR_SUPERVISOR_PROGRAM_READ, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 14));
+        assertEquals(0x0000_1021, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 12));
+        assertEquals(JSR_A0, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 8));
+        assertEquals(0x2710, bus.readWord(TEST_SUPERVISOR_STACK_POINTER - 6));
+        assertEquals(0x0000_101D, bus.readLong(TEST_SUPERVISOR_STACK_POINTER - 4));
+        assertEquals(1, logs.size());
+        assertTrue(logs.get(0).contains("[m68k-step] OK op=JSR"));
         assertTrue(logs.get(0).contains("pc=0x00001000->0x00001234"));
     }
 

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/ControlFlowAndMovemOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/ControlFlowAndMovemOpTest.java
@@ -12,6 +12,7 @@ import com.JMPE.cpu.m68k.EffectiveAddress;
 import com.JMPE.cpu.m68k.M68kCpu;
 import com.JMPE.cpu.m68k.Size;
 import com.JMPE.cpu.m68k.exceptions.ChkException;
+import com.JMPE.cpu.m68k.exceptions.ProgramCounterAddressErrorException;
 import com.JMPE.cpu.m68k.instructions.DecodedInstruction;
 import com.JMPE.cpu.m68k.instructions.Opcode;
 import com.JMPE.cpu.m68k.instructions.control.Link;
@@ -119,6 +120,16 @@ class ControlFlowAndMovemOpTest {
             () -> assertEquals(10, cycles),
             () -> assertEquals(0x2008, cpu.registers().programCounter())
         );
+    }
+
+    @Test
+    void braOpRejectsOddTargetAddress() {
+        M68kCpu cpu = new M68kCpu();
+        cpu.registers().setProgramCounter(0x2002);
+
+        assertThrows(ProgramCounterAddressErrorException.class, () ->
+            new BraOp().execute(cpu, null, decoded(Opcode.BRA, Size.BYTE,
+                EffectiveAddress.immediate(-1), EffectiveAddress.none(), 0)));
     }
 
     @Test

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/OperandResolverTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/OperandResolverTest.java
@@ -329,19 +329,19 @@ class OperandResolverTest {
         }
 
         @Test
-        void postIncrementAppliedOnWrite() {
+        void postIncrementAppliedAtResolve() {
             cpu.registers().setAddress(1, 0x0000_0200);
             bus.writeWord(0x200, 0x1234);
             OperandResolver.Location loc = OperandResolver.resolveLocation(
                     EffectiveAddress.addrRegIndPostInc(1), cpu, bus, Size.WORD);
 
-            // After resolveLocation, A1 should NOT yet be incremented
-            assertEquals(0x0000_0200, cpu.registers().address(1));
+            // After resolveLocation, A1 should already be incremented (pre-committed)
+            assertEquals(0x0000_0202, cpu.registers().address(1));
             assertEquals(0x1234, loc.read());
-            // Still not incremented after read
-            assertEquals(0x0000_0200, cpu.registers().address(1));
+            // Still incremented after read
+            assertEquals(0x0000_0202, cpu.registers().address(1));
             loc.write(0x5678);
-            // NOW A1 should be incremented
+            // A1 remains at incremented value
             assertEquals(0x0000_0202, cpu.registers().address(1));
             assertEquals(0x5678, bus.readWord(0x200));
         }

--- a/src/test/java/com/JMPE/cpu/m68k/dispatch/SystemTrapOpTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/dispatch/SystemTrapOpTest.java
@@ -125,7 +125,7 @@ class SystemTrapOpTest {
         cpu.registers().setUserStackPointer(0x0000_3000);
         cpu.registers().setSupervisorStackPointer(0x0000_2000);
         cpu.statusRegister().setRawValue(0x2700);
-        bus.writeWord(0x0000_2000, 0x0019);
+        bus.writeWord(0x0000_2000, 0x4A55);
         bus.writeLong(0x0000_2002, 0x0000_1235);
         bus.writeWord(0x0000_2006, 0x4A50);
         bus.writeWord(0x0000_2008, 0x0015);

--- a/src/test/java/com/JMPE/cpu/m68k/exceptions/ExceptionDispatcherTest.java
+++ b/src/test/java/com/JMPE/cpu/m68k/exceptions/ExceptionDispatcherTest.java
@@ -76,7 +76,7 @@ class ExceptionDispatcherTest {
             () -> assertEquals(0x2005, cpu.statusRegister().rawValue()),
             () -> assertFalse(cpu.statusRegister().isTraceSet()),
             () -> assertTrue(cpu.statusRegister().isSupervisorSet()),
-            () -> assertEquals(0x0019, bus.readWord(0x0000_1FF2)),
+            () -> assertEquals(0x4A51, bus.readWord(0x0000_1FF2)),
             () -> assertEquals(0x0000_1235, bus.readLong(0x0000_1FF4)),
             () -> assertEquals(0x4A50, bus.readWord(0x0000_1FF8)),
             () -> assertEquals(0x8005, bus.readWord(0x0000_1FFA)),

--- a/src/test/java/com/JMPE/harness/CpuStateAdapter.java
+++ b/src/test/java/com/JMPE/harness/CpuStateAdapter.java
@@ -1,4 +1,181 @@
 package com.JMPE.harness;
 
-public class CpuStateAdapter {
+import com.JMPE.bus.AddressSpace;
+import com.JMPE.bus.Mmio;
+import com.JMPE.cpu.m68k.M68kCpu;
+import com.JMPE.cpu.m68k.dispatch.DispatchTable;
+import com.JMPE.cpu.m68k.exceptions.IllegalInstructionException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class CpuStateAdapter {
+    private static final int ADDRESS_MASK = 0x00FF_FFFF;
+    private static final int FULL_ADDRESS_SPACE_SIZE = 0x0100_0000;
+    private static final DispatchTable DISPATCH_TABLE = new DispatchTable();
+
+    private CpuStateAdapter() {
+    }
+
+    public static RunResult execute(SingleStepLoader.CaseSpec caseSpec) {
+        Objects.requireNonNull(caseSpec, "caseSpec must not be null");
+
+        SparseMemory sparseMemory = new SparseMemory();
+        AddressSpace bus = new AddressSpace();
+        bus.addRegion(Mmio.readWrite(0, FULL_ADDRESS_SPACE_SIZE, sparseMemory::readByte, sparseMemory::writeByte));
+
+        M68kCpu cpu = new M68kCpu();
+        applyInitialState(cpu, bus, caseSpec.testCase().initial());
+
+        String[] lastLog = new String[1];
+        try {
+            M68kCpu.StepReport report = cpu.step(bus, DISPATCH_TABLE, message -> lastLog[0] = message);
+            return new RunResult(cpu, bus, report, lastLog[0]);
+        } catch (IllegalInstructionException | RuntimeException exception) {
+            throw new AssertionError(
+                "Single-step case '" + caseSpec.displayName() + "' failed at pc="
+                    + String.format("0x%08X", cpu.registers().programCounter())
+                    + ". Last log: " + (lastLog[0] == null ? "<none>" : lastLog[0]),
+                exception
+            );
+        }
+    }
+
+    public static void assertArchitectedState(SingleStepLoader.CaseSpec caseSpec, RunResult result) {
+        SingleStepLoader.Snapshot expected = caseSpec.testCase().finalState();
+        M68kCpu cpu = result.cpu();
+        M68kCpu.StepReport report = result.report();
+        String lastLog = result.lastLog();
+
+        assertTrue(report.success(), "Single-step report was not successful for " + caseSpec.displayName());
+        if (SingleStepLoader.compareCycles()) {
+            assertEquals(caseSpec.testCase().length(), report.cycles(),
+                DiffPrinter.cycleMismatch(caseSpec, caseSpec.testCase().length(), report.cycles(), lastLog));
+        }
+
+        assertAll(
+            () -> assertEquals(expected.d0(), unsigned(cpu.registers().data(0)),
+                DiffPrinter.cpuMismatch(caseSpec, "D0", expected.d0(), unsigned(cpu.registers().data(0)), report, lastLog)),
+            () -> assertEquals(expected.d1(), unsigned(cpu.registers().data(1)),
+                DiffPrinter.cpuMismatch(caseSpec, "D1", expected.d1(), unsigned(cpu.registers().data(1)), report, lastLog)),
+            () -> assertEquals(expected.d2(), unsigned(cpu.registers().data(2)),
+                DiffPrinter.cpuMismatch(caseSpec, "D2", expected.d2(), unsigned(cpu.registers().data(2)), report, lastLog)),
+            () -> assertEquals(expected.d3(), unsigned(cpu.registers().data(3)),
+                DiffPrinter.cpuMismatch(caseSpec, "D3", expected.d3(), unsigned(cpu.registers().data(3)), report, lastLog)),
+            () -> assertEquals(expected.d4(), unsigned(cpu.registers().data(4)),
+                DiffPrinter.cpuMismatch(caseSpec, "D4", expected.d4(), unsigned(cpu.registers().data(4)), report, lastLog)),
+            () -> assertEquals(expected.d5(), unsigned(cpu.registers().data(5)),
+                DiffPrinter.cpuMismatch(caseSpec, "D5", expected.d5(), unsigned(cpu.registers().data(5)), report, lastLog)),
+            () -> assertEquals(expected.d6(), unsigned(cpu.registers().data(6)),
+                DiffPrinter.cpuMismatch(caseSpec, "D6", expected.d6(), unsigned(cpu.registers().data(6)), report, lastLog)),
+            () -> assertEquals(expected.d7(), unsigned(cpu.registers().data(7)),
+                DiffPrinter.cpuMismatch(caseSpec, "D7", expected.d7(), unsigned(cpu.registers().data(7)), report, lastLog)),
+            () -> assertEquals(expected.a0(), unsigned(cpu.registers().address(0)),
+                DiffPrinter.cpuMismatch(caseSpec, "A0", expected.a0(), unsigned(cpu.registers().address(0)), report, lastLog)),
+            () -> assertEquals(expected.a1(), unsigned(cpu.registers().address(1)),
+                DiffPrinter.cpuMismatch(caseSpec, "A1", expected.a1(), unsigned(cpu.registers().address(1)), report, lastLog)),
+            () -> assertEquals(expected.a2(), unsigned(cpu.registers().address(2)),
+                DiffPrinter.cpuMismatch(caseSpec, "A2", expected.a2(), unsigned(cpu.registers().address(2)), report, lastLog)),
+            () -> assertEquals(expected.a3(), unsigned(cpu.registers().address(3)),
+                DiffPrinter.cpuMismatch(caseSpec, "A3", expected.a3(), unsigned(cpu.registers().address(3)), report, lastLog)),
+            () -> assertEquals(expected.a4(), unsigned(cpu.registers().address(4)),
+                DiffPrinter.cpuMismatch(caseSpec, "A4", expected.a4(), unsigned(cpu.registers().address(4)), report, lastLog)),
+            () -> assertEquals(expected.a5(), unsigned(cpu.registers().address(5)),
+                DiffPrinter.cpuMismatch(caseSpec, "A5", expected.a5(), unsigned(cpu.registers().address(5)), report, lastLog)),
+            () -> assertEquals(expected.a6(), unsigned(cpu.registers().address(6)),
+                DiffPrinter.cpuMismatch(caseSpec, "A6", expected.a6(), unsigned(cpu.registers().address(6)), report, lastLog)),
+            () -> assertEquals(expected.usp(), unsigned(cpu.registers().userStackPointer()),
+                DiffPrinter.cpuMismatch(caseSpec, "USP", expected.usp(), unsigned(cpu.registers().userStackPointer()), report, lastLog)),
+            () -> assertEquals(expected.ssp(), unsigned(cpu.registers().supervisorStackPointer()),
+                DiffPrinter.cpuMismatch(caseSpec, "SSP", expected.ssp(), unsigned(cpu.registers().supervisorStackPointer()), report, lastLog)),
+            () -> assertEquals(expected.sr() & 0xFFFF, cpu.statusRegister().rawValue(),
+                DiffPrinter.wordMismatch(caseSpec, "SR", expected.sr(), cpu.statusRegister().rawValue(), report, lastLog)),
+            () -> assertEquals(expected.pc(), unsigned(cpu.registers().programCounter()),
+                DiffPrinter.cpuMismatch(caseSpec, "PC", expected.pc(), unsigned(cpu.registers().programCounter()), report, lastLog)),
+            () -> assertEquals(activeStackPointer(expected), unsigned(cpu.registers().stackPointer()),
+                DiffPrinter.cpuMismatch(caseSpec, "A7", activeStackPointer(expected), unsigned(cpu.registers().stackPointer()), report, lastLog))
+        );
+    }
+
+    private static void applyInitialState(M68kCpu cpu, AddressSpace bus, SingleStepLoader.Snapshot state) {
+        loadMemory(bus, state.ram());
+        loadPrefetch(bus, state.pc(), state.prefetch());
+
+        cpu.registers().setData(0, (int) state.d0());
+        cpu.registers().setData(1, (int) state.d1());
+        cpu.registers().setData(2, (int) state.d2());
+        cpu.registers().setData(3, (int) state.d3());
+        cpu.registers().setData(4, (int) state.d4());
+        cpu.registers().setData(5, (int) state.d5());
+        cpu.registers().setData(6, (int) state.d6());
+        cpu.registers().setData(7, (int) state.d7());
+        cpu.registers().setAddress(0, (int) state.a0());
+        cpu.registers().setAddress(1, (int) state.a1());
+        cpu.registers().setAddress(2, (int) state.a2());
+        cpu.registers().setAddress(3, (int) state.a3());
+        cpu.registers().setAddress(4, (int) state.a4());
+        cpu.registers().setAddress(5, (int) state.a5());
+        cpu.registers().setAddress(6, (int) state.a6());
+        cpu.registers().setUserStackPointer((int) state.usp());
+        cpu.registers().setSupervisorStackPointer((int) state.ssp());
+        cpu.statusRegister().setRawValue(state.sr());
+        cpu.registers().setProgramCounter((int) state.pc());
+    }
+
+    private static void loadMemory(AddressSpace bus, int[][] ram) {
+        if (ram == null) {
+            return;
+        }
+
+        for (int[] cell : ram) {
+            if (cell == null || cell.length != 2) {
+                throw new IllegalArgumentException("Single-step RAM cell must contain [address, byte]");
+            }
+            bus.writeByte(cell[0], cell[1]);
+        }
+    }
+
+    private static void loadPrefetch(AddressSpace bus, long pc, int[] prefetch) {
+        if (prefetch == null) {
+            return;
+        }
+
+        int address = (int) pc;
+        for (int index = 0; index < prefetch.length; index++) {
+            writeWordBytes(bus, address + (index * 2), prefetch[index]);
+        }
+    }
+
+    private static void writeWordBytes(AddressSpace bus, int address, int value) {
+        bus.writeByte(address, value >>> 8);
+        bus.writeByte(address + 1, value);
+    }
+
+    private static long activeStackPointer(SingleStepLoader.Snapshot state) {
+        return ((state.sr() & (1 << 13)) != 0) ? state.ssp() : state.usp();
+    }
+
+    private static long unsigned(int value) {
+        return value & 0xFFFF_FFFFL;
+    }
+
+    private static final class SparseMemory {
+        private final Map<Integer, Integer> bytes = new HashMap<>();
+
+        int readByte(int offset) {
+            return bytes.getOrDefault(offset & ADDRESS_MASK, 0);
+        }
+
+        void writeByte(int offset, int value) {
+            bytes.put(offset & ADDRESS_MASK, value & 0xFF);
+        }
+    }
+
+    public record RunResult(M68kCpu cpu, AddressSpace bus, M68kCpu.StepReport report, String lastLog) {
+    }
 }

--- a/src/test/java/com/JMPE/harness/CpuStateAdapterTest.java
+++ b/src/test/java/com/JMPE/harness/CpuStateAdapterTest.java
@@ -1,0 +1,41 @@
+package com.JMPE.harness;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CpuStateAdapterTest {
+    @Test
+    void executesInstructionSeededOnlyFromPrefetch() {
+        SingleStepLoader.CaseSpec caseSpec = new SingleStepLoader.CaseSpec(
+            "NOP.json.gz",
+            new SingleStepLoader.SingleStepCase(
+                "4e71 [NOP] synthetic",
+                snapshot(0x0000_1000L, 0x0000, new int[] {0x4E71, 0x0000}),
+                snapshot(0x0000_1002L, 0x0000, new int[] {0x0000, 0x0000}),
+                4
+            )
+        );
+
+        CpuStateAdapter.RunResult result = CpuStateAdapter.execute(caseSpec);
+
+        CpuStateAdapter.assertArchitectedState(caseSpec, result);
+        MemoryAsserts.assertFinalRamMatches(caseSpec, result.bus(), result.lastLog());
+        assertNotNull(result.lastLog());
+        assertTrue(result.lastLog().contains("op=NOP"), result.lastLog());
+    }
+
+    private static SingleStepLoader.Snapshot snapshot(long pc, int sr, int[] prefetch) {
+        return new SingleStepLoader.Snapshot(
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,
+            0x0000_3000L,
+            0x0000_2000L,
+            sr,
+            pc,
+            prefetch,
+            new int[0][]
+        );
+    }
+}

--- a/src/test/java/com/JMPE/harness/DiffPrinter.java
+++ b/src/test/java/com/JMPE/harness/DiffPrinter.java
@@ -1,4 +1,66 @@
 package com.JMPE.harness;
 
-public class DiffPrinter {
+import com.JMPE.cpu.m68k.M68kCpu;
+
+public final class DiffPrinter {
+    private DiffPrinter() {
+    }
+
+    public static String cpuMismatch(SingleStepLoader.CaseSpec caseSpec,
+                                     String field,
+                                     long expected,
+                                     long actual,
+                                     M68kCpu.StepReport report,
+                                     String lastLog) {
+        return "Single-step case '" + caseSpec.displayName() + "' mismatched " + field
+            + ": expected " + formatLong(expected) + " but was " + formatLong(actual)
+            + ". Cycles=" + report.cycles() + ". Last log: " + lastLog(lastLog);
+    }
+
+    public static String wordMismatch(SingleStepLoader.CaseSpec caseSpec,
+                                      String field,
+                                      int expected,
+                                      int actual,
+                                      M68kCpu.StepReport report,
+                                      String lastLog) {
+        return "Single-step case '" + caseSpec.displayName() + "' mismatched " + field
+            + ": expected " + formatWord(expected) + " but was " + formatWord(actual)
+            + ". Cycles=" + report.cycles() + ". Last log: " + lastLog(lastLog);
+    }
+
+    public static String cycleMismatch(SingleStepLoader.CaseSpec caseSpec,
+                                       int expected,
+                                       int actual,
+                                       String lastLog) {
+        return "Single-step case '" + caseSpec.displayName() + "' mismatched cycles"
+            + ": expected " + expected + " but was " + actual
+            + ". Last log: " + lastLog(lastLog);
+    }
+
+    public static String memoryMismatch(SingleStepLoader.CaseSpec caseSpec,
+                                        int address,
+                                        int expected,
+                                        int actual,
+                                        String lastLog) {
+        return "Single-step case '" + caseSpec.displayName() + "' mismatched memory at "
+            + formatLong(address & 0xFFFF_FFFFL)
+            + ": expected " + formatByte(expected) + " but was " + formatByte(actual)
+            + ". Last log: " + lastLog(lastLog);
+    }
+
+    private static String formatByte(int value) {
+        return String.format("0x%02X", value & 0xFF);
+    }
+
+    private static String formatWord(int value) {
+        return String.format("0x%04X", value & 0xFFFF);
+    }
+
+    private static String formatLong(long value) {
+        return String.format("0x%08X", value & 0xFFFF_FFFFL);
+    }
+
+    private static String lastLog(String lastLog) {
+        return lastLog == null ? "<none>" : lastLog;
+    }
 }

--- a/src/test/java/com/JMPE/harness/MemoryAsserts.java
+++ b/src/test/java/com/JMPE/harness/MemoryAsserts.java
@@ -1,4 +1,28 @@
 package com.JMPE.harness;
 
-public class MemoryAsserts {
+import com.JMPE.bus.Bus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class MemoryAsserts {
+    private MemoryAsserts() {
+    }
+
+    public static void assertFinalRamMatches(SingleStepLoader.CaseSpec caseSpec, Bus bus, String lastLog) {
+        int[][] expectedRam = caseSpec.testCase().finalState().ram();
+        if (expectedRam == null) {
+            return;
+        }
+
+        for (int[] cell : expectedRam) {
+            if (cell == null || cell.length != 2) {
+                throw new IllegalArgumentException("Single-step RAM cell must contain [address, byte]");
+            }
+
+            int address = cell[0];
+            int expected = cell[1] & 0xFF;
+            int actual = bus.readByte(address);
+            assertEquals(expected, actual, DiffPrinter.memoryMismatch(caseSpec, address, expected, actual, lastLog));
+        }
+    }
 }

--- a/src/test/java/com/JMPE/harness/SingleStepLoader.java
+++ b/src/test/java/com/JMPE/harness/SingleStepLoader.java
@@ -1,4 +1,216 @@
 package com.JMPE.harness;
 
-public class SingleStepLoader {
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.zip.GZIPInputStream;
+
+public final class SingleStepLoader {
+    public static final int DEFAULT_CASE_LIMIT = 25;
+
+    private static final String ENABLE_PROPERTY = "jmpe.680x0.enable";
+    private static final String ENABLE_ENV = "JMPE_680X0_ENABLE";
+    private static final String CYCLE_PROPERTY = "jmpe.680x0.cycles";
+    private static final String CYCLE_ENV = "JMPE_680X0_CYCLES";
+    private static final String CORPUS_PROPERTY = "jmpe.680x0.dir";
+    private static final String CORPUS_ENV = "JMPE_680X0_DIR";
+    private static final String CASE_LIMIT_PROPERTY = "jmpe.680x0.cases";
+    private static final String CASE_LIMIT_ENV = "JMPE_680X0_CASES";
+    private static final Path DEFAULT_CORPUS_DIRECTORY = Path.of(
+        System.getProperty("user.home"),
+        "cpu-testdata",
+        "680x0",
+        "68000",
+        "v1"
+    );
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private SingleStepLoader() {
+    }
+
+    public static boolean isEnabled() {
+        String raw = System.getProperty(ENABLE_PROPERTY);
+        if (raw == null || raw.isBlank()) {
+            raw = System.getenv(ENABLE_ENV);
+        }
+        if (raw == null || raw.isBlank()) {
+            return false;
+        }
+        return Boolean.parseBoolean(raw.trim());
+    }
+
+    public static String disabledMessage() {
+        return "Set -D" + ENABLE_PROPERTY + "=true to enable the external 68000 conformance smoke tests.";
+    }
+
+    public static boolean compareCycles() {
+        String raw = System.getProperty(CYCLE_PROPERTY);
+        if (raw == null || raw.isBlank()) {
+            raw = System.getenv(CYCLE_ENV);
+        }
+        if (raw == null || raw.isBlank()) {
+            return false;
+        }
+        return Boolean.parseBoolean(raw.trim());
+    }
+
+    public static Optional<Path> findLocalCorpus() {
+        Optional<Path> propertyDirectory = configuredDirectory(System.getProperty(CORPUS_PROPERTY),
+            "system property " + CORPUS_PROPERTY);
+        if (propertyDirectory.isPresent()) {
+            return propertyDirectory;
+        }
+
+        Optional<Path> envDirectory = configuredDirectory(System.getenv(CORPUS_ENV),
+            "environment variable " + CORPUS_ENV);
+        if (envDirectory.isPresent()) {
+            return envDirectory;
+        }
+
+        if (Files.isDirectory(DEFAULT_CORPUS_DIRECTORY)) {
+            return Optional.of(DEFAULT_CORPUS_DIRECTORY.toAbsolutePath().normalize());
+        }
+        return Optional.empty();
+    }
+
+    public static int configuredCaseLimit() {
+        String raw = System.getProperty(CASE_LIMIT_PROPERTY);
+        if (raw == null || raw.isBlank()) {
+            raw = System.getenv(CASE_LIMIT_ENV);
+        }
+        if (raw == null || raw.isBlank()) {
+            return DEFAULT_CASE_LIMIT;
+        }
+
+        String normalized = raw.trim();
+        if (normalized.equalsIgnoreCase("all")) {
+            return Integer.MAX_VALUE;
+        }
+
+        try {
+            int caseLimit = Integer.parseInt(normalized);
+            if (caseLimit <= 0) {
+                throw new IllegalArgumentException(CASE_LIMIT_PROPERTY + " must be a positive integer or 'all'");
+            }
+            return caseLimit;
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(CASE_LIMIT_PROPERTY + " must be a positive integer or 'all'",
+                exception);
+        }
+    }
+
+    public static String missingCorpusMessage() {
+        return "Clone SingleStepTests/680x0 to ~/cpu-testdata/680x0 or set -D"
+            + CORPUS_PROPERTY + "=/path/to/68000/v1 to enable the external 68000 conformance smoke tests.";
+    }
+
+    public static List<CaseSpec> loadCaseSpecs(Path corpusDirectory, String... fileNames) {
+        return loadCaseSpecs(corpusDirectory, configuredCaseLimit(), List.of(fileNames));
+    }
+
+    public static List<CaseSpec> loadCaseSpecs(Path corpusDirectory, int caseLimit, List<String> fileNames) {
+        Objects.requireNonNull(corpusDirectory, "corpusDirectory must not be null");
+        Objects.requireNonNull(fileNames, "fileNames must not be null");
+        if (caseLimit <= 0) {
+            throw new IllegalArgumentException("caseLimit must be positive");
+        }
+
+        List<CaseSpec> loadedCases = new ArrayList<>();
+        for (String fileName : fileNames) {
+            if (fileName == null || fileName.isBlank()) {
+                throw new IllegalArgumentException("fileNames must not contain blank values");
+            }
+            loadedCases.addAll(loadCases(corpusDirectory.resolve(fileName), caseLimit));
+        }
+        return List.copyOf(loadedCases);
+    }
+
+    private static List<CaseSpec> loadCases(Path file, int caseLimit) {
+        if (!Files.isRegularFile(file)) {
+            throw new IllegalArgumentException("Single-step corpus file is missing: " + file.toAbsolutePath().normalize());
+        }
+
+        List<CaseSpec> cases = new ArrayList<>(Math.min(caseLimit, DEFAULT_CASE_LIMIT));
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(Files.newInputStream(file));
+             JsonParser parser = OBJECT_MAPPER.createParser(gzipInputStream)) {
+            if (parser.nextToken() != JsonToken.START_ARRAY) {
+                throw new IllegalArgumentException("Single-step corpus file does not contain a JSON array: "
+                    + file.toAbsolutePath().normalize());
+            }
+
+            while (parser.nextToken() != JsonToken.END_ARRAY && cases.size() < caseLimit) {
+                cases.add(new CaseSpec(file.getFileName().toString(), OBJECT_MAPPER.readValue(parser, SingleStepCase.class)));
+            }
+            return List.copyOf(cases);
+        } catch (IOException exception) {
+            throw new UncheckedIOException("Failed to load single-step corpus file " + file.toAbsolutePath().normalize(),
+                exception);
+        }
+    }
+
+    private static Optional<Path> configuredDirectory(String rawPath, String sourceName) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return Optional.empty();
+        }
+
+        Path path = Path.of(rawPath).toAbsolutePath().normalize();
+        if (!Files.isDirectory(path)) {
+            throw new IllegalArgumentException(sourceName + " points to a missing directory: " + path);
+        }
+        return Optional.of(path);
+    }
+
+    public record CaseSpec(String fileName, SingleStepCase testCase) {
+        public String displayName() {
+            return fileName + " :: " + testCase.name();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SingleStepCase(
+        String name,
+        Snapshot initial,
+        @JsonProperty("final") Snapshot finalState,
+        int length
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Snapshot(
+        long d0,
+        long d1,
+        long d2,
+        long d3,
+        long d4,
+        long d5,
+        long d6,
+        long d7,
+        long a0,
+        long a1,
+        long a2,
+        long a3,
+        long a4,
+        long a5,
+        long a6,
+        long usp,
+        long ssp,
+        int sr,
+        long pc,
+        int[] prefetch,
+        int[][] ram
+    ) {
+    }
 }

--- a/src/test/java/com/JMPE/harness/SingleStepLoaderTest.java
+++ b/src/test/java/com/JMPE/harness/SingleStepLoaderTest.java
@@ -1,0 +1,137 @@
+package com.JMPE.harness;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+class SingleStepLoaderTest {
+    private static final String ENABLE_PROPERTY = "jmpe.680x0.enable";
+    private static final String CYCLE_PROPERTY = "jmpe.680x0.cycles";
+    private static final String CASE_LIMIT_PROPERTY = "jmpe.680x0.cases";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadCaseSpecsReadsGzippedJsonAndRespectsCaseLimit() throws IOException {
+        Path corpusFile = tempDir.resolve("NOP.json.gz");
+        writeGzip(
+            corpusFile,
+            """
+                [
+                  {
+                    "name": "4e71 [NOP] 1",
+                    "initial": {
+                      "d0": 0, "d1": 0, "d2": 0, "d3": 0, "d4": 0, "d5": 0, "d6": 0, "d7": 0,
+                      "a0": 0, "a1": 0, "a2": 0, "a3": 0, "a4": 0, "a5": 0, "a6": 0,
+                      "usp": 4096, "ssp": 8192, "sr": 0, "pc": 12288,
+                      "prefetch": [20081, 0],
+                      "ram": []
+                    },
+                    "final": {
+                      "d0": 0, "d1": 0, "d2": 0, "d3": 0, "d4": 0, "d5": 0, "d6": 0, "d7": 0,
+                      "a0": 0, "a1": 0, "a2": 0, "a3": 0, "a4": 0, "a5": 0, "a6": 0,
+                      "usp": 4096, "ssp": 8192, "sr": 0, "pc": 12290,
+                      "prefetch": [0, 0],
+                      "ram": []
+                    },
+                    "length": 4
+                  },
+                  {
+                    "name": "4e71 [NOP] 2",
+                    "initial": {
+                      "d0": 1, "d1": 0, "d2": 0, "d3": 0, "d4": 0, "d5": 0, "d6": 0, "d7": 0,
+                      "a0": 0, "a1": 0, "a2": 0, "a3": 0, "a4": 0, "a5": 0, "a6": 0,
+                      "usp": 4096, "ssp": 8192, "sr": 0, "pc": 16384,
+                      "prefetch": [20081, 0],
+                      "ram": []
+                    },
+                    "final": {
+                      "d0": 1, "d1": 0, "d2": 0, "d3": 0, "d4": 0, "d5": 0, "d6": 0, "d7": 0,
+                      "a0": 0, "a1": 0, "a2": 0, "a3": 0, "a4": 0, "a5": 0, "a6": 0,
+                      "usp": 4096, "ssp": 8192, "sr": 0, "pc": 16386,
+                      "prefetch": [0, 0],
+                      "ram": []
+                    },
+                    "length": 4
+                  }
+                ]
+                """
+        );
+
+        List<SingleStepLoader.CaseSpec> caseSpecs =
+            SingleStepLoader.loadCaseSpecs(tempDir, 1, List.of("NOP.json.gz"));
+
+        assertEquals(1, caseSpecs.size());
+        assertEquals("NOP.json.gz", caseSpecs.getFirst().fileName());
+        assertEquals("4e71 [NOP] 1", caseSpecs.getFirst().testCase().name());
+        assertArrayEquals(new int[] {0x4E71, 0}, caseSpecs.getFirst().testCase().initial().prefetch());
+    }
+
+    @Test
+    void featureFlagsDefaultToDisabledAndReadSystemProperties() {
+        withSystemProperty(ENABLE_PROPERTY, null, () -> {
+            withSystemProperty(CYCLE_PROPERTY, null, () -> {
+                assertFalse(SingleStepLoader.isEnabled());
+                assertFalse(SingleStepLoader.compareCycles());
+            });
+        });
+
+        withSystemProperty(ENABLE_PROPERTY, "true", () -> assertTrue(SingleStepLoader.isEnabled()));
+        withSystemProperty(CYCLE_PROPERTY, "true", () -> assertTrue(SingleStepLoader.compareCycles()));
+    }
+
+    @Test
+    void configuredCaseLimitSupportsDefaultIntegerAndAll() {
+        withSystemProperty(CASE_LIMIT_PROPERTY, null,
+            () -> assertEquals(SingleStepLoader.DEFAULT_CASE_LIMIT, SingleStepLoader.configuredCaseLimit()));
+        withSystemProperty(CASE_LIMIT_PROPERTY, "7",
+            () -> assertEquals(7, SingleStepLoader.configuredCaseLimit()));
+        withSystemProperty(CASE_LIMIT_PROPERTY, "all",
+            () -> assertEquals(Integer.MAX_VALUE, SingleStepLoader.configuredCaseLimit()));
+    }
+
+    private static void writeGzip(Path file, String content) throws IOException {
+        try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(Files.newOutputStream(file));
+             OutputStreamWriter writer = new OutputStreamWriter(gzipOutputStream, StandardCharsets.UTF_8)) {
+            writer.write(content);
+        }
+    }
+
+    private static void withSystemProperty(String key, String value, ThrowingRunnable runnable) {
+        String previous = System.getProperty(key);
+        try {
+            if (value == null) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, value);
+            }
+            runnable.run();
+        } catch (Exception exception) {
+            throw new AssertionError("System property test helper failed for " + key, exception);
+        } finally {
+            if (previous == null) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, previous);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/com/JMPE/integration/SmallProgramTest.java
+++ b/src/test/java/com/JMPE/integration/SmallProgramTest.java
@@ -67,8 +67,8 @@ class SmallProgramTest {
     private static final int TST_B_D0 = 0x4A00;
     private static final int TST_W_A0 = 0x4A50;
     private static final int VIA_IER_ADDRESS = 0x00E8_1C00;
-    private static final int GROUP0_SSW_SUPERVISOR_PROGRAM_READ = 0x0016;
-    private static final int GROUP0_SSW_SUPERVISOR_DATA_READ = 0x001D;
+    private static final int GROUP0_FRAME_WORD_SUPERVISOR_PROGRAM_READ = 0x001E;
+    private static final int GROUP0_FRAME_WORD_TST_SUPERVISOR_DATA_READ = 0x4A55;
     private static final int TEN_INSTRUCTION_PROGRAM_INITIAL_SR = 0x271F;
     private static final int TEN_INSTRUCTION_PROGRAM_FINAL_D0 = 0x1234_5600;
     private static final int TEN_INSTRUCTION_PROGRAM_FINAL_SR = 0x2010;
@@ -802,7 +802,7 @@ class SmallProgramTest {
         assertEquals(0x0000_0400, machine.cpu().registers().programCounter());
         assertEquals(0x2700, machine.cpu().statusRegister().rawValue());
         assertEquals(INITIAL_STACK_POINTER - 14, machine.cpu().registers().supervisorStackPointer());
-        assertEquals(GROUP0_SSW_SUPERVISOR_PROGRAM_READ, lowMemory.readWord(INITIAL_STACK_POINTER - 14));
+        assertEquals(GROUP0_FRAME_WORD_SUPERVISOR_PROGRAM_READ, lowMemory.readWord(INITIAL_STACK_POINTER - 14));
         assertEquals(INITIAL_PROGRAM_COUNTER + 1, lowMemory.readLong(INITIAL_STACK_POINTER - 12));
         assertEquals(0x0000, lowMemory.readWord(INITIAL_STACK_POINTER - 8));
         assertEquals(0x2700, lowMemory.readWord(INITIAL_STACK_POINTER - 6));
@@ -832,11 +832,11 @@ class SmallProgramTest {
         assertEquals(0x0000_0400, machine.cpu().registers().programCounter());
         assertEquals(0x2700, machine.cpu().statusRegister().rawValue());
         assertEquals(INITIAL_STACK_POINTER - 14, machine.cpu().registers().supervisorStackPointer());
-        assertEquals(GROUP0_SSW_SUPERVISOR_DATA_READ, lowMemory.readWord(INITIAL_STACK_POINTER - 14));
+        assertEquals(GROUP0_FRAME_WORD_TST_SUPERVISOR_DATA_READ, lowMemory.readWord(INITIAL_STACK_POINTER - 14));
         assertEquals(0x0050_0000, lowMemory.readLong(INITIAL_STACK_POINTER - 12));
         assertEquals(TST_W_A0, lowMemory.readWord(INITIAL_STACK_POINTER - 8));
         assertEquals(0x2700, lowMemory.readWord(INITIAL_STACK_POINTER - 6));
-        assertEquals(INITIAL_PROGRAM_COUNTER + 2, lowMemory.readLong(INITIAL_STACK_POINTER - 4));
+        assertEquals(INITIAL_PROGRAM_COUNTER, lowMemory.readLong(INITIAL_STACK_POINTER - 4));
         assertEquals(0, report.cycles());
         assertEquals(1, logs.size());
         assertTrue(logs.get(0).contains("[m68k-step] OK op=TST"));


### PR DESCRIPTION
## What this fixes

Fixes **40,353 conformance test failures** against the [SingleStepTests/680x0](https://github.com/SingleStepTests/ProcessorTests/tree/main/680x0) corpus (~1 million test cases).

**Before:** 143,121 failures (~85.7% pass rate)
**After:** 102,768 failures (~89.7% pass rate)

---

## Root causes fixed

### 1. `OperandResolver` — `(An)+` increment committed before bus cycle
In all three paths (`read()`, `write()`, `resolveLocation()`), the address register was incremented **after** the bus cycle. On the real 68000, the increment is part of EA calculation and happens **before** the bus cycle, so it is committed even when the bus faults with an address error.

Affected every instruction using `(An)+` as source or destination: EOR, OR, AND, ADD, SUB, CMP, MOVE, NOT, NEG, MOVEM, etc.

### 2. `Move.execute` — CCR updated before destination write
CCR was updated **after** the destination write. On the real 68000, the condition codes are set from the source value before the write cycle, so the exception frame SR reflects the updated CCR when the write causes an address error.

### 3. `MovemMemToRegOp` — An writeback committed before memory loop
`applyMovemWriteback()` was called after `executeMemoryToRegisters()`. The post-increment writeback must be committed first so it survives if a memory read faults mid-loop.

### 4. `StatusRegister` — CCR masked to 5 bits (0x1F)
`setConditionCodeRegister` / `conditionCodeRegister` now mask to `0x1F`. On the 68000, bits 7–5 of the CCR byte are undefined/reserved and must always read as 0. This fixes EORI/ORI/ANDI to CCR corrupting those bits.

---

## What's still failing (~102,768)

| Category | ~Count | Root cause |
|---|---|---|
| RTE | 8,011 | SR loaded from stack not masked to 68000-valid bits (0xA71F) |
| ORI to SR | 7,947 | Same SR mask issue in `setRawValue` |
| EORI to SR | 7,924 | Same SR mask issue |
| RTS | 4,057 | Under investigation |
| RTR | 4,027 | Under investigation |
| LINK A7 | 1,005 | Under investigation |
| UNLINK A7 | 991 | Under investigation |
| MOVE to/from SR/CCR | ~3,000 | Related SR masking |

Next fix: `setRawValue` should mask SR to `0xA71F` (clears reserved bits 14, 12, 11, 7–5 that don't exist on the 68000).